### PR TITLE
Tweak light styles and fix favicon

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -15,7 +15,7 @@ const { title } = Astro.props;
 		<meta charset="UTF-8" />
 		<meta name="description" content="Astro description" />
 		<meta name="viewport" content="width=device-width" />
-		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+		<link rel="icon" type="image/svg+xml" href="/withtheranks-astro/favicon.svg" />
 		<meta name="generator" content={Astro.generator} />
 		<title>{title}</title>
 		<link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -24,8 +24,9 @@ Right now we're not using any preprocessors, just CSS variables, but Tailwind is
     --gradient-dark-end: #0D003E;
 
     /* Light theme variables */
-    --light-bg-color: #ffffff;
-    --light-text-color: #000000;
+    --light-bg-rgb: 255, 255, 255;
+    --light-bg-color: rgb(var(--light-bg-rgb));
+    --light-text-color: #070218;
 
     /* Light theme gradient colors */
     --gradient-light-start: rgba(233, 230, 255, 0);
@@ -49,6 +50,7 @@ Right now we're not using any preprocessors, just CSS variables, but Tailwind is
 
 [data-theme="light"] {
     --main-bg-color: var(--light-bg-color);
+    --main-bg-rgb: var(--light-bg-rgb);
     --main-text-color: var(--light-text-color);
     --gradient-dark-start: var(--gradient-light-start);
     --gradient-dark-end: var(--gradient-light-end);
@@ -62,9 +64,9 @@ Right now we're not using any preprocessors, just CSS variables, but Tailwind is
     color: #bfd5ff;
 }
 
-[data-theme="light"] header[data-astro-cid-j7pv25f6]::after {
-    background: linear-gradient(var(--gradient-light-start),
-            var(--gradient-light-end) 100%);
+[data-theme="light"] header::after {
+    background: linear-gradient(rgba(var(--light-bg-rgb), 0),
+            rgba(var(--light-bg-rgb), 1) 100%);
 }
 
 [data-theme="light"] .button {


### PR DESCRIPTION
This pull requests updates a few things in the light styles:

- make text color a deep dark blue as opposed to black, matching the blue tilt of the dark style
- update the gradient in front of the logo to fade into the background (see screenshot comparison below)

It also fixes path to favicon.

Before:
![Screenshot from 2024-01-17 21-20-46](https://github.com/With-the-Ranks/withtheranks-astro/assets/3048335/2801298d-1188-462d-ba52-0c2d75a93bb5)

After:
![Screenshot from 2024-01-17 21-57-04](https://github.com/With-the-Ranks/withtheranks-astro/assets/3048335/b3c3f786-3540-4f57-a8bb-e1734bdd7873)

Dark style for reference:
![Screenshot from 2024-01-17 21-22-44](https://github.com/With-the-Ranks/withtheranks-astro/assets/3048335/04a39ba1-18fb-45c9-a975-d5b011560102)
