### PR TITLE
Move nav to component and remove from home page for now

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,24 +5,6 @@ import "animate.css";
 ---
 
 <Layout title="With the Ranks">
-	<!-- TODO: Move to component -->
-	<nav
-		class="max-w-screen-2xl w-10/12 mx-auto pt-10 animate__animated animate__fadeIn animate__delay-2s"
-	>
-		<div class="flex justify-between">
-			<ul class="flex">
-				<li class="inline-block">
-					<a href="/">Home</a>
-				</li>
-				<li class="inline-block"><a href="/work">Our Work</a></li>
-				<li class="inline-block"><a href="/blog">Blog</a></li>
-			</ul>
-			<button id="theme-toggle" class="theme-toggle-button">
-				<i class="fas fa-moon"></i> <!-- Default icon -->
-			</button>
-		</div>
-	</nav>
-
 	<main class="animate__animated animate__fadeIn animate__slow py-20 md:py-40">
 		<div class="debug hidden" id="color_picker">
 			<label for="favcolor">Logo colors:</label>


### PR DESCRIPTION
This PR moves the nav to a component and removes it from the homepage for now (until we have more pages).