### PR TITLE
Add Spoke Docs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,9 @@
         "astro": "^4.1.2",
         "tailwindcss": "^3.4.1",
         "typescript": "^5.3.3"
+      },
+      "devDependencies": {
+        "@types/node": "^20.11.5"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1328,6 +1331,15 @@
       "version": "2.0.10",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.10.tgz",
       "integrity": "sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA=="
+    },
+    "node_modules/@types/node": {
+      "version": "20.11.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.5.tgz",
+      "integrity": "sha512-g557vgQjUUfN76MZAN/dt1z3dzcUsimuysco0KeluHgrPdJXkP/XdAURgyO2W9fZWHRtRBiVKzKn8vyOAwlG+w==",
+      "devOptional": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/unist": {
       "version": "3.0.2",
@@ -6945,6 +6957,12 @@
       "dependencies": {
         "semver": "^7.3.8"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "devOptional": true
     },
     "node_modules/unherit": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -17,5 +17,8 @@
     "astro": "^4.1.2",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.3.3"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.5"
   }
 }

--- a/src/components/Button.astro
+++ b/src/components/Button.astro
@@ -1,13 +1,23 @@
 ---
-const { text, link } = Astro.props;
+import type { LinkProps } from "../types";
+
+interface Props extends LinkProps {
+    marginClass?: string;
+}
+
+const { text, link, marginClass } = Astro.props;
 ---
 
-<a class="button rounded-2xl" href={link}>{text}</a>
+<a class=`button rounded-2xl ${marginClass}` href={link}>{text}</a>
 
 <style>
     .button {
         text-decoration: none;
-        background: linear-gradient(to bottom right, var(--stop-two-color), var(--stop-two-color));
+        background: linear-gradient(
+            to bottom right,
+            var(--stop-two-color),
+            var(--stop-two-color)
+        );
         font-weight: bold;
         padding: 1rem 2rem;
         font-size: 1.5rem;
@@ -15,7 +25,11 @@ const { text, link } = Astro.props;
         width: auto;
 
         &:hover {
-            background: linear-gradient(to bottom right, var(--stop-one-color), var(--stop-two-color));
+            background: linear-gradient(
+                to bottom right,
+                var(--stop-one-color),
+                var(--stop-two-color)
+            );
         }
     }
 </style>

--- a/src/components/Button.astro
+++ b/src/components/Button.astro
@@ -2,13 +2,13 @@
 import type { LinkProps } from "../types";
 
 interface Props extends LinkProps {
-    marginClass?: string;
+    class?: string;
 }
 
-const { text, link, marginClass } = Astro.props;
+const { text, link, class: customClass } = Astro.props;
 ---
 
-<a class=`button rounded-2xl ${marginClass}` href={link}>{text}</a>
+<a class=`button rounded-2xl ${customClass}` href={link}>{text}</a>
 
 <style>
     .button {

--- a/src/components/DocsCollection/DocsCollectionButton.astro
+++ b/src/components/DocsCollection/DocsCollectionButton.astro
@@ -7,4 +7,4 @@ interface Props extends LinkProps {}
 const { text, link } = Astro.props;
 ---
 
-<Button text={text} link={link} marginClass="m-2" />
+<Button text={text} link={link} class="m-2" />

--- a/src/components/DocsCollection/DocsCollectionButton.astro
+++ b/src/components/DocsCollection/DocsCollectionButton.astro
@@ -1,0 +1,10 @@
+---
+import type { LinkProps } from "../../types";
+import Button from "../Button.astro";
+
+interface Props extends LinkProps {}
+
+const { text, link } = Astro.props;
+---
+
+<Button text={text} link={link} marginClass="m-2" />

--- a/src/components/DocsCollection/SpokeDocsList.astro
+++ b/src/components/DocsCollection/SpokeDocsList.astro
@@ -1,0 +1,42 @@
+---
+import * as fs from "fs";
+import { kebabCasetoTitleCase } from "../../utils.ts";
+import { type LinkProps } from "../../types.ts";
+
+type SpokeDocCollectionType = "for-spoke-admins" | "for-spoke-texters";
+
+interface Props {
+    collectionType: SpokeDocCollectionType;
+}
+
+const { collectionType } = Astro.props;
+
+const DOCS_DIRECTORY = `${process.cwd()}/src/pages/docs/spoke`;
+const HTML_EXTENSION_LENGTH = ".html".length;
+const SPOKE_LINK_PATH = "/withtheranks-astro/docs/spoke";
+
+const path = DOCS_DIRECTORY + "/" + collectionType;
+const fileNames = fs.readdirSync(path);
+const collectionFileNames = fileNames.filter(
+    (fileName) => fileName != "index.astro",
+);
+
+const docList: LinkProps[] = collectionFileNames.map((fileName) => {
+    const endOfSlug = fileName.length - HTML_EXTENSION_LENGTH - 1;
+    const slug = fileName.substring(0, endOfSlug);
+
+    const docLink = `${SPOKE_LINK_PATH}/${collectionType.toString()}/${slug}`;
+    const docTitle = kebabCasetoTitleCase(slug);
+    return { text: docTitle, link: docLink };
+});
+---
+
+<ul>
+    {
+        docList.map((doc: LinkProps) => (
+            <li class="m-2">
+                <a href={doc.link}>{doc.text}</a>
+            </li>
+        ))
+    }
+</ul>

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -1,17 +1,21 @@
+---
+import ThemeToggleButton from "./ThemeToggleButton.astro";
+---
+
 <nav
     class="max-w-screen-2xl w-10/12 mx-auto pt-10 animate__animated animate__fadeIn animate__delay-2s"
 >
-    <div class="flex justify-end">
-        <!-- <ul class="flex">
+    <div class="flex justify-between">
+        <ul class="flex">
             <li class="inline-block">
-                <a href="/">Home</a>
+                <a href="/withtheranks-astro">Home</a>
             </li>
-            <li class="inline-block"><a href="/work">Our Work</a></li>
-            <li class="inline-block"><a href="/blog">Blog</a></li>
-        </ul> -->
-        <button id="theme-toggle" class="theme-toggle-button">
-            <i class="fas fa-moon"></i>
-            <!-- Default icon -->
-        </button>
+            <!-- <li class="inline-block"><a href="/work">Our Work</a></li>
+            <li class="inline-block"><a href="/blog">Blog</a></li> -->
+            <li class="inline-block">
+                <a href="/withtheranks-astro/docs">Docs</a>
+            </li>
+        </ul>
+        <ThemeToggleButton />
     </div>
 </nav>

--- a/src/components/ThemeToggleButton.astro
+++ b/src/components/ThemeToggleButton.astro
@@ -1,0 +1,44 @@
+<button id="theme-toggle" class="theme-toggle-button">
+    <i class="fas fa-moon"></i>
+    <!-- Default icon -->
+</button>
+
+<script>
+    import { type themeMode } from "../styles/types.ts";
+
+    const toggleButton = document.getElementById(
+        "theme-toggle",
+    ) as HTMLButtonElement;
+
+    function updateIcon(theme: themeMode) {
+        const toggleIcon = toggleButton.querySelector("i");
+
+        if (theme === "light") {
+            toggleIcon?.classList.remove("fa-sun");
+            toggleIcon?.classList.add("fa-moon");
+        } else {
+            toggleIcon?.classList.remove("fa-moon");
+            toggleIcon?.classList.add("fa-sun");
+        }
+    }
+
+    function setTheme(newTheme: themeMode) {
+        document.documentElement.setAttribute("data-theme", newTheme);
+        updateIcon(newTheme);
+        localStorage.setItem("theme", newTheme);
+    }
+
+    toggleButton.addEventListener("click", () => {
+        const currentTheme =
+            document.documentElement.getAttribute("data-theme");
+        const newTheme = currentTheme === "dark" ? "light" : "dark";
+        setTheme(newTheme);
+    });
+
+    // Check local storage for a stored theme preference
+    document.addEventListener("DOMContentLoaded", () => {
+        const storedTheme =
+            (localStorage.getItem("theme") as themeMode) || "dark";
+        setTheme(storedTheme);
+    });
+</script>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -16,7 +16,11 @@ const { title } = Astro.props;
 		<meta charset="UTF-8" />
 		<meta name="description" content="Astro description" />
 		<meta name="viewport" content="width=device-width" />
-		<link rel="icon" type="image/svg+xml" href="/withtheranks-astro/favicon.svg" />
+		<link
+			rel="icon"
+			type="image/svg+xml"
+			href="/withtheranks-astro/favicon.svg"
+		/>
 		<meta name="generator" content={Astro.generator} />
 		<title>{title}</title>
 		<link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -25,12 +29,18 @@ const { title } = Astro.props;
 			href="https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400;0,700;1,400;1,700&display=swap"
 			rel="stylesheet"
 		/>
-		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css">
+		<link
+			rel="stylesheet"
+			href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css"
+		/>
 	</head>
 	<body>
 		<Nav />
 		<slot />
-
-		<footer class="w-10/12 mx-auto"><p class="text-base font-sans text-slate-400 text-center">With the Ranks is 100% worker-owned, and we don't use cookies.</p></footer>
+		<footer class="w-10/12 mx-auto">
+			<p class="text-base font-sans text-slate-400 text-center">
+				With the Ranks is 100% worker-owned, and we don't use cookies.
+			</p>
+		</footer>
 	</body>
 </html>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,5 +1,6 @@
 ---
 import "../styles/main.css";
+import Nav from "../components/Nav.astro";
 
 interface Props {
 	title: string;
@@ -27,6 +28,7 @@ const { title } = Astro.props;
 		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css">
 	</head>
 	<body>
+		<Nav />
 		<slot />
 
 		<footer class="w-10/12 mx-auto"><p class="text-base font-sans text-slate-400 text-center">With the Ranks is 100% worker-owned, and we don't use cookies.</p></footer>

--- a/src/pages/docs/index.astro
+++ b/src/pages/docs/index.astro
@@ -1,0 +1,19 @@
+---
+import DocsCollection from "../../components/DocsCollection/DocsCollectionButton.astro";
+import Layout from "../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">With The Ranks Documentation</h2>
+			<DocsCollection
+				text="Spoke Texting"
+				link="/withtheranks-astro/docs/spoke"
+			/>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-admins/10dlc-glossary.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/10dlc-glossary.astro
@@ -1,0 +1,124 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">10dlc Glossary</h2>
+
+			<p>Here is a handy reference for 10DLC terminology:</p>
+			<table>
+				<thead>
+					<tr>
+						<td> Term</td>
+						<td> Definition</td>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td> P2P</td>
+						<td>
+							Person-to-person SMS describes messages sent to an
+							individual's handset&nbsp;<strong
+								>from a handset</strong
+							>. We have traditionally thought of Spoke as P2P,
+							however, it is now categorized as A2P.
+						</td>
+					</tr>
+					<tr>
+						<td> A2P</td>
+						<td>
+							Application-to-person SMS describes messages sent to
+							an individual's handset <strong
+								>via an application</strong
+							>. Traffic sent via an application is considered A2P
+							by the telecom industry regardless of whether that
+							message was initiated by a person or a program.
+						</td>
+					</tr>
+					<tr>
+						<td> Long Code Phone Number</td>
+						<td>
+							A standard 10-digit phone number in the North
+							American Numbering Plan. Your personal phone number
+							is a long code number.
+						</td>
+					</tr>
+					<tr>
+						<td> Short Code Phone Number</td>
+						<td>
+							A 5 or 6 digit phone number requiring a rigorous
+							registration by the sender and explicit opt in from
+							recipients in exchange for fewer sending
+							restrictions.
+						</td>
+					</tr>
+					<tr>
+						<td> 10-Digit Long Code&nbsp;(10DLC)</td>
+						<td>
+							A system allowing businesses to send A2P-type
+							messages over standard 10-digit long code numbers
+							providing better quality to recipients and lower
+							filtering risk to senders.
+						</td>
+					</tr>
+					<tr>
+						<td> Brand</td>
+						<td>
+							Brand registration identifies who a business is on
+							the carrier network.
+						</td>
+					</tr>
+					<tr>
+						<td> Campaign</td>
+						<td>
+							Campaign registration identifies what type of
+							content a business is sending on the network.
+							Different use cases are subject to different
+							restrictions.
+						</td>
+					</tr>
+					<tr>
+						<td> The Campaign Registry&nbsp;(TCR)&nbsp;</td>
+						<td>
+							The entity responsible for managing brand and
+							campaign registration.
+						</td>
+					</tr>
+					<tr>
+						<td> Campaign Verify</td>
+						<td>
+							The entity responsible for verifying 10DLC campaigns
+							using the <a
+								href="https://docs.spokerewired.com/article/132-transitioning-to-10dlc"
+								target="_blank">Political special use case</a
+							>.
+						</td>
+					</tr>
+					<tr>
+						<td> Campaign Service Provider (CSP)</td>
+						<td>
+							A business responsible for sending messages on
+							behalf of multiple brands and able to manage brand
+							and campaign registration on their behalf. Politics
+							Rewired is a campaign service provider.
+						</td>
+					</tr>
+					<tr>
+						<td> Direct Connect Aggregator (DCA)</td>
+						<td>
+							A company that has a direct connection to a Mobile
+							Network Operator (MNO) Gateway and transmits
+							messages on behalf of its customers or “content
+							providers”. Twilio is an example of a DCA.
+						</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-admins/10dlc-pricing.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/10dlc-pricing.astro
@@ -1,0 +1,48 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">10dlc Pricing</h2>
+
+			<h2>Spoke Rewired Pricing</h2><p>
+				Spoke Rewired offers its lowest prices to organizations
+				registered with 10DLC. We continue to support sending messages
+				without registration at an additional cost (imposed by
+				carriers).
+			</p><p>
+				Please refer to the <a
+					href="https://www.politicsrewired.com/pricing"
+					target="_blank">Spoke Rewired pricing page on our website</a
+				> for more information.
+			</p><h2>Non-compliance with 10DLC messaging requirements</h2><p>
+				Carriers may levy the following types of fees for non-compliance
+				with 10DLC messaging requirements:
+			</p><p><strong>Content Violation</strong></p><p>
+				T-Mobile may charge a $10,000 fee for <strong
+					>each unique instance</strong
+				> of content violation by a sender. Content violations are
+				usually SHAFT violations (Sex, Hate, Alcohol, Firearms, Tobacco)
+				but would also include spam messages or phishing attempts. We
+				are not especially worried about this type of content being sent
+				by the customers we have chosen to work with, however, it is
+				very important that all texting program directors familiarize
+				themselves with these violation types!
+			</p><p><strong>Message Routing</strong></p><p>
+				Additional fees are assessed for message routing violations on
+				the network. Spoke Rewired was built with compliance in mind
+				from day one and you will not have to worry about these kinds of
+				fees as a customer.
+			</p><p>
+				If, however, we find that you have intentionally circumvented
+				the safeguards built into our software, we will pass on any
+				message routing non-compliance fees.
+			</p>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-admins/10dlc.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/10dlc.astro
@@ -1,0 +1,152 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">10dlc</h2>
+
+			<p>
+				<strong>10DLC</strong> (short for <strong
+					>10 Digit Long Code</strong
+				>) is a new policy from cell phone carriers for organizations
+				and businesses that use software to send text messages. The
+				10DLC scheme requires organizations and businesses to register
+				with cell phone carriers and describe their usage before using
+				software like Spoke Rewired to send SMS and MMS messages.
+			</p><h2>I’m a Spoke customer, what do I need to do?</h2><p>
+				Spoke Rewired fully supports sending messages with 10DLC. To
+				take advantage of our lowest prices and improved deliverability,
+				you should register your Spoke organization for a 10DLC brand.
+			</p><p>
+				<strong>Please see</strong><a
+					href="https://docs.spokerewired.com/article/132-transitioning-to-10dlc"
+					><strong>Adopting 10DLC</strong></a
+				><strong> to start the registration process.</strong>
+			</p><p>
+				While carriers have not implemented a strict deadline for
+				registering for 10DLC, they have begun to charge higher fees and
+				impose stricter filters for unregistered messages. As a result,
+				we highly recommend all existing organizations register for
+				10DLC as soon as possible.
+			</p><p>
+				If the time required to complete registration is an issue, you
+				can continue to send unregistered traffic at a higher cost per
+				message while undergoing the registration process. As soon as
+				you complete the registration process and your registration is
+				vetted and approved, we will transition you to our registered
+				pricing plan so you can take advantage of our lowest message
+				prices.
+			</p><p>
+				We are committed to supporting you throughout the registration
+				process, and offer registration and ongoing 10DLC enrollment at
+				no additional cost. Contact us at any time at <a
+					href="mailto:support@spokerewired.com"
+					>support@spokerewired.com</a
+				>.
+			</p><h2>I’m new to Spoke, how does this affect me?</h2><p>
+				If you need to send messages as quickly as possible, you can
+				begin sending unregistered messages while starting the 10DLC
+				registration process. As soon as you complete the registration
+				process and your registration is vetted and approved, we will
+				transition you to our registered pricing plan so you can take
+				advantage of our lowest message prices.
+			</p><p>
+				<strong>Please see</strong><a
+					href="https://docs.spokerewired.com/article/132-transitioning-to-10dlc"
+					><strong>Adopting 10DLC</strong></a
+				><strong> to start the registration process.</strong>
+			</p><p>
+				We are committed to supporting you throughout the process;
+				contact us at any time at <a
+					href="mailto:support@spokerewired.com"
+					>support@spokerewired.com</a
+				>.
+			</p><h2>Pricing</h2><p>
+				Spoke Rewired offers its lowest prices to organizations
+				registered with 10DLC. We continue to support sending messages
+				without registration at an additional cost (imposed by
+				carriers).
+			</p><p>
+				Please refer to the Spoke Rewired pricing page on our website
+				for more information.
+			</p><h2>
+				Comparison of 10DLC registered sending vs unregistered
+			</h2><table>
+				<tbody
+					><tr
+						><td><strong>Feature</strong></td><td
+							><strong>10DLC Registered</strong></td
+						><td><strong>Unregistered</strong></td></tr
+					><tr
+						><td><strong>“From” phone number</strong></td><td
+							>1 phone number per location</td
+						><td>Multiple phone numbers per location</td></tr
+					><tr
+						><td><strong>Deliverability</strong></td><td
+							>Less filtering on links and message content</td
+						><td>Stricter filters on links and message content</td
+						></tr
+					><tr
+						><td><strong>Pricing</strong></td><td
+							>Lowest possible prices</td
+						><td>Increasing penalty fees</td></tr
+					><tr
+						><td><strong>Message delivery info</strong></td><td
+							>Improved</td
+						><td>Basic</td></tr
+					></tbody
+				>
+			</table><h2>History and background</h2><p>
+				Before the development of 10DLC, cell phone carriers discouraged
+				organizations and businesses from using software to send
+				messages from local phone numbers (in carrier jargon: long
+				codes) to other local phone numbers. Carriers pushed
+				organizations to instead purchase <a
+					href="https://en.wikipedia.org/wiki/Short_code"
+					>short code numbers</a
+				> or <a
+					href="https://en.wikipedia.org/wiki/Toll-free_telephone_number"
+					>toll-free numbers</a
+				>, which required lengthy and expensive setup procedures and
+				opt-in procedures.
+			</p><p>
+				In the 2010s, software was developed to avoid these extensive
+				setup costs and procedures. Instead of sending messages from
+				short-code or toll-free numbers, this software provided ways to
+				send text messages from individual cell phones to other cell
+				phones. This concept, known as peer-to-peer texting, allowed
+				political campaigns and organizers to quickly contact voters and
+				volunteers. Eventually, this ecosystem developed into modern
+				texting software, which allows users to directly send text
+				messages via internet telecom services without managing
+				individual cell phones.
+			</p><p>
+				The advent of software-based texting lowered technical and
+				financial barriers for sending texts, leading to an increase in
+				spam. In response, cell phone carriers introduced the 10DLC
+				policy to provide a sanctioned platform for organizations and
+				businesses to send SMS and MMS messages using long codes. The
+				stated objective of the 10DLC program is to protect consumers
+				from unwanted spam while still allowing businesses to better
+				connect with their customers.
+			</p><p>10DLC is intended to reduce spam in two ways:</p><ol>
+				<li>
+					Organizations register themselves as a 10DLC brand, and all
+					messages sent on 10DLC channels will be associated with this
+					brand. This registration costs money and deanonymizes
+					message traffic, increasing the risk to spammers.
+				</li><li>
+					Increased costs to send 10DLC messages and increasing
+					penalty fees on unregistered messages. A small increase in
+					price can eliminate spammer profits, and spammers aiming to
+					avoid 10DLC registration face even higher costs.
+				</li>
+			</ol>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-admins/about-spoke-rewired.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/about-spoke-rewired.astro
@@ -1,0 +1,43 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">About Spoke Rewired</h2>
+
+			<p>
+				Spoke Rewired is a political messaging application designed for
+				sending mass-scale peer-to-peer text messages to volunteers and
+				voters. Through the application, you can organize texting
+				<a
+					href="https://docs.spokerewired.com/article/25-campaigns"
+					target="_blank">campaigns</a
+				>, which provide the structure and tools needed to connect <a
+					href="https://docs.spokerewired.com/article/32-user-roles"
+					target="_blank">texters</a
+				> in your organization with your organization's contacts. Spoke is
+				meant to be used in combination with a CRM. Spoke is not a CRM and
+				should not be used as one.
+			</p><h5><em>Some of Spoke's key features include:</em></h5><ul>
+				<li>Messaging platform with script and survey integration</li>
+				<li>Interaction script and survey editing</li>
+				<li>Automatic and manual conversation assignment</li>
+				<li>Automatic handling and processing of your contact lists</li>
+				<li>Opt-out handling</li>
+			</ul><p>
+				To begin learning about Spoke Rewired, see
+				<a
+					href="https://docs.spokerewired.com/article/23-how-to-use-documentation"
+					>How to Use this Documentation</a
+				> or search for a topic on the <a
+					href="https://docs.spokerewired.com/">homepage</a
+				>.
+			</p>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-admins/auto-assignment.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/auto-assignment.astro
@@ -1,0 +1,96 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">Auto Assignment</h2>
+
+			<p>
+				You can utilize
+				<strong>auto-assignment</strong> to easily and automatically distribute
+				texting assignments to your texters, without needing to manually
+				divide texts or replenish assignments when texters run out of messages.
+				This keeps texts flowing to texters who are able to send more messages
+				without overburdening administrators with tedious assignment and
+				reassignment tasks.
+			</p><p>
+				There are three steps to set up auto-assignment for a campaign:
+			</p><p>
+				<strong>1. Enable Auto-Assignment:</strong>Click <strong
+					>Autoassign Mode</strong
+				> at the bottom of your campaign settings page, then toggle the top
+				switch to enable autoassign.&nbsp;
+			</p><blockquote>
+				<strong>Note:</strong>Toggling the bottom switch will
+				automatically release unhandled replies to the <a
+					href="https://docs.spokerewired.com/article/110-request-form"
+					>request form</a
+				> after a pre-set period of time (for example, 30 minutes). This
+				can be a helpful feature down the road, but if you're just learning
+				how to manage auto-assignment, we recommend keeping if toggled off.
+			</blockquote><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/5fc9400b4664bd7a123ea853/file-FVKPtDqJ8t.png"
+					alt=""
+					style="display: block; margin: auto;"
+				/>
+			</p><p>
+				<strong>2. Turn on the Request Form:</strong>Click <a
+					href="https://docs.spokerewired.com/article/66-manage-assignment-control"
+					target="_blank"><strong>Assignment Control</strong></a
+				><strong>&nbsp;</strong>on&nbsp;the administration <a
+					href="https://docs.spokerewired.com/article/52-dashboards"
+					target="_blank">dashboard</a
+				>, then toggle the switch to enable assignment. Set the
+				assignment type (initials or replies) and the maximum number of
+				messages a texter can request per assignment. This will activate
+				the <a
+					href="https://docs.spokerewired.com/article/110-request-form"
+					target="_blank">request form</a
+				> for your texters, allowing them to request assignments.
+			</p><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/5fca9443eb7cc612aa3550b2/file-WvTtjrLqjX.png"
+					alt=""
+					style="display: block; margin: auto;"
+				/>
+			</p><p>
+				<strong>3. Set Up&nbsp;</strong><strong
+					>Auto-Approval:
+				</strong>Click <strong>Settings</strong> on the administration dashboard,
+				then select <strong>Auto Approve</strong>beneath "Default Text
+				Request Auto-Approval Level." This will make it so that when
+				texters request an assignment via the request form, that
+				assignment is automatically approved in a matter of seconds. If
+				you wish to have administrators or <a
+					href="https://docs.spokerewired.com/article/6-user-roles"
+					target="_blank">Supervolunteers</a
+				> manually approved requests, you can set this option for <strong
+					>Approval Required</strong
+				>. (We recommend&nbsp;using Auto Approve in most cases.)&nbsp;
+			</p><blockquote>
+				<strong>Note:</strong> You only need to set Auto Approve as your
+				default setting once. Once set, all future texters invited to your
+				organization will be set to have their assignments automatically
+				approved. However, changing the default setting does not change the
+				auto-approval level of texters already in your organization. You
+				can change this setting on an individual basis by going to the
+				<strong>People</strong>window within the administration <a
+					href="https://docs.spokerewired.com/article/52-dashboards"
+					target="_blank">dashboard</a
+				>.
+			</blockquote><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/5fc6a179d580ce55a38b3410/file-jKIfkJUxR2.png"
+					alt=""
+					style="display: block; margin: auto;"
+				/>
+			</p><h2></h2>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-admins/billing-pricing.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/billing-pricing.astro
@@ -1,0 +1,58 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">Billing Pricing</h2>
+
+			<h3>Billing Periods</h3><p>
+				Usage-based products (e.g., SMS segments, phone numbers) are
+				billed at the end of each month. License-based products (e.g.,
+				consulting, database services) are billed at the top of the
+				month.
+			</p><h3>Payment Methods</h3><p>
+				Invoices are sent via email and can be paid by card, ACH, or
+				wire transfer. We accept all major credit cards. If you are
+				unable to pay by card or transfer, please <a
+					href="mailto:support@spokerewired.com">email us</a
+				> to inquire about alternative payment methods.
+			</p><h3>Usage Reports</h3><p>
+				If you require an ad-hoc usage report mid-month, please <a
+					href="mailto:support@spokerewired.com">email us</a
+				> and include the name of your organization and the time period desired.&nbsp;
+			</p><h3>Pricing</h3><h5>Texts</h5><p>
+				Under our Standard pricing model, inbound and outbound SMS
+				segments are priced at 1¢ and <a
+					href="https://docs.spokerewired.com/article/86-include-an-image-in-a-message"
+					>MMS</a
+				> segments are priced at 3¢. You can read more about segments <a
+					href="https://docs.spokerewired.com/article/89-segments-and-encodings"
+					>here</a
+				>.&nbsp;
+			</p><h5>Number Lookups</h5><p>
+				Contact validation is priced at 1/4¢ ($.0025) per cell. Use our
+				Filter Landlines feature to confirm that your contact lists are
+				textable!
+			</p><h5>Consulting Services</h5><p>
+				To inquire about our consulting offerings, please <a
+					href="mailto:support@spokerewired.com">email us</a
+				> or book a <a href="https://calendly.com/politics-rewired"
+					>time to chat</a
+				>! Our team of organizers, former leaders of the Bernie 2020
+				National Texting Team, offer extra assistance in planning,
+				building, and analyzing your campaigns
+			</p><h5>Reporting and Integrations</h5><p>
+				To inquire about additional reporting tools (e.g. read replica
+				access, custom dashboards) and integrations with other tools
+				(e.g. Slack), please<a href="mailto:support@spokerewired.com">
+					email us</a
+				>.&nbsp;
+			</p>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-admins/build-a-campaign.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/build-a-campaign.astro
@@ -1,0 +1,377 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">Build A Campaign</h2>
+
+			<p>
+				Building a <a
+					href="https://docs.spokerewired.com/article/25-campaigns"
+					>campaign</a
+				> lets you reach out to your contacts in a systematic and scripted
+				way. Spoke administrators and owners are able to create campaigns
+				from the Spoke administration <a
+					href="https://docs.spokerewired.com/article/52-dashboards"
+					>dashboard</a
+				>.
+			</p><p>
+				After you create and start a campaign, you can continue editing
+				all information <u
+					><b>with the exception of the contact list.</b></u
+				>  You must set up your VAN integration before creating a new
+				campaign - for more information, see VAN Integration &amp; List
+				Loading. (link) To &quot;add&quot; contacts to a campaign,
+				duplicate the campaign by selecting <a
+					href="https://docs.spokerewired.com/article/112-copy-a-campaign"
+					>Copy Campaign</a
+				> from the individual campaign page and load new contacts into the
+				duplicate campaign.
+			</p><br /><p>
+				Note: some options are not available when using the Basic
+				builder mode. To switch to Advanced mode and configure all
+				settings, click on the <i><b>Builder Mode</b></i> dropdown menu at
+				the top of the page.
+			</p><br /><p>
+				To build a new campaign, use the following steps:
+			</p><h3><b>Step 1: Initiate a new campaign</b></h3><p>
+				From the Campaigns page of the administrator dashboard, click
+				the <b>plus (+)</b> button in the lower right corner, and click on
+				<i><b>Create Blank</b></i> (the pencil icon). This will pull up a
+				new campaign settings page.
+			</p><p style="text-align: center;" class="align-center">
+				<img
+					src="https://lh6.googleusercontent.com/zXY0WDynV61SRJOYCzP9seOMFOkXB2suaDwbdV9RmMr6kYsEf2XEEontWEt-nuo65Oszu5619oK0v0TT4p76sOwwghw2EsvJ8VrX9RSYmKMpxdqMzIy0_B_hJBvysOmPxH80TJv2rk6KrgaTJY5o_yM"
+					style="max-width: 100%; text-align: center;"
+				/>
+			</p><br /><p>
+				You can also duplicate an existing campaign by selecting <b
+					>Copy Campaign</b
+				> from the individual campaign page. This will often be the more
+				efficient option.
+			</p><br /><p>
+				For more information about copying campaigns, see <a
+					href="https://docs.spokerewired.com/article/112-copy-a-campaign"
+					target="_blank">Copy a Campaign</a
+				>.
+			</p><br /><h3><b>Step 2: Enter campaign information</b></h3><p>
+				The first window in the campaign settings page is called <b
+					>Basics</b
+				> and includes fields for basic campaign information. Enter values
+				for the following fields:
+			</p><ul>
+				<li>
+					<b>Title</b> — <span>required</span> — This title will be visible
+					to texters and will be used for email notifications and for naming
+					export files. Campaign titles can be useful for the <a
+						href="https://docs.spokerewired.com/article/69-bulk-script-editor"
+						>bulk script editor</a
+					> or for your own analyses and record keeping, so you should
+					group similar campaigns according to a carefully considered naming
+					convention.
+				</li><li>
+					<b>Description</b> — <span>required</span> — This field can be
+					used to include instructions, additional information, or even
+					an inspirational message for your texters.
+				</li><li>
+					<b>Due Date</b> — <span>required</span> — The date on which the
+					campaign &quot;ends.&quot; After this date, texters cannot send
+					initial messages for this campaign, though they can still respond
+					to replies as long as the campaign is not archived. Setting a
+					<a href="https://docs.spokerewired.com/article/60-due-dates"
+						>due date</a
+					> can ensure, for example, that you never recruit for an event
+					after the event date has passed.
+				</li><li>
+					<b>Intro HTML</b> — <span>optional</span> — The HTML that is
+					displayed to texters as part of the assignment banner.
+				</li><li>
+					Logo Image URL — <span>optional</span> — The URL for an image
+					that is displayed to texters as part of the assignment banner.
+					&lt;add file formats&gt;
+				</li><li>
+					<b>Primary Color</b>— <span>optional</span> — The color that
+					is displayed to texters as part of the assignment banner. Use
+					the slider to choose a color, or enter a hex color code.
+				</li>
+			</ul><p>
+				When you are finished, click the <i
+					><b>SAVE AND GOTO NEXT SECTION</b></i
+				> button.
+			</p><br /><h3>Step 3: Set texting hours</h3><p>
+				To set texting hours:
+			</p><ol>
+				<li>Open the<b> Texting Hours</b> window.</li><li>
+					Enter a start time. Use a 12-hour time, such as 9 am.
+				</li><li>
+					Enter an end time. Use a 12-hour time, such as 9 pm.
+				</li><li>
+					Select a default timezone to apply to contacts without ZIP
+					codes.
+				</li><li>Click<i><b> Save</b></i>.</li>
+			</ol><p>
+				Note: In order to comply with regulations regarding consumer
+				telephone contact, texting cannot start before 9am local time
+				and must end no later than 9pm local time. Spoke will
+				automatically honor the timeframe you set relative to the
+				uploaded zip code of each contact. We recommend ending your
+				texting by 8:30pm local time to ensure deliverability within the
+				allowable texting hours.
+			</p><br /><p>
+				For more information, see <a
+					href="https://docs.spokerewired.com/article/48-texting-hours"
+					>Texting Hours</a
+				>.
+			</p><br /><h3>Step 4: Import contacts to the campaign</h3><p>
+				From the <b>Contacts</b>window, perform the following steps:
+			</p><h5>To Import a CSV:</h5><ol>
+				<li>
+					In the<i><b> Contact Source</b></i> menu, select <b>CSV</b> from
+					the drop down menu.
+				</li><li>
+					Click <i><b>Select a File</b></i> or drag and drop the file into
+					the dotted-line rectangle.
+				</li><li>
+					Locate the contact-list CSV file and click <i><b>Open</b></i
+					>.
+				</li><li>
+					After uploading a csv file, a popup menu will appear
+					allowing you to map the column headers of your csv to the
+					required column headers (First Name, Last Name, and Cell
+					Phone), as well as map the optional headers (Zip and
+					External ID).
+				</li><li>Click <i><b>Save</b></i>.</li><li>
+					<span>Optional</span> — Exclude contacts who also appear as contacts
+					within another campaign.<ol>
+						<li>
+							Start typing the name of the campaign you want to
+							use for filtering (or open the drop-down menu).
+						</li><li>Click the campaign name in the list.</li>
+					</ol>
+				</li><li>
+					Repeat until you&#39;ve finished adding the campaigns you
+					want to exclude.
+				</li><li>
+					Then hit <i><b>Save</b></i>. The name of your csv will now
+					appear in the file upload box with a green background,
+					indicating a successful upload.
+				</li>
+			</ol><br /><p>
+				For more information and images about uploading your CSV
+				contacts list file, see <a
+					href="https://docs.spokerewired.com/article/64-contact-lists"
+					>Contact Lists</a
+				>.
+			</p><p><b>To Import a list from VAN:</b></p><p>
+				<span
+					>(You must already have your VAN integration set up. To do
+					this, see
+				</span>
+				<a
+					href="https://docs.spokerewired.com/article/93-van-list-loading"
+					>VAN Integration &amp; List Loading</a
+				>.)
+			</p><p>
+				For VAN lists, you cannot filter out contacts that are also in
+				another campaign.
+			</p><ol>
+				<li>
+					Select <b>Integration</b> from the<i
+						><b> Contact Source</b></i
+					> menu.
+				</li><li>
+					<p>
+						Select the integration you wish to use (i.e. Votebuilder
+						/ VAN), and click the refresh button at the far right of
+						the screen.
+					</p><p>
+						<img
+							src="https://lh4.googleusercontent.com/ZY_JVjQv2X9J6mfD4xSnZ8QXmYfFaK1Vi1mwj7NuI0nY3m5hYHGNzyuTW8Ce094TLwkN4_zFteM_zFexaDZPjdoLiCeZVmV4wLFUKx65jce2EH5xltMmhgivVIASqqV1EYHr8_s-K2icp0pDWlTC9X8"
+							style="width: 97.08%; max-width: 100%; "
+						/>
+					</p>
+				</li><li>
+					Browse for the correct list under the <i
+						><b>Choose a list</b></i
+					> menu, then press<i><b> Save.</b></i>
+				</li><li>
+					Review the upload notifications for processing notes.
+				</li>
+			</ol><p>
+				When you are finished, click the <i
+					><b>SAVE AND GOTO NEXT SECTION</b></i
+				> button.
+			</p><p>
+				<b
+					>Note: Once you start the campaign, you will not be able to
+					modify or add to the contact list.</b
+				>
+			</p><br /><h3><b>Step 5: Optional — Filter Landlines</b></h3><h3>
+				<b
+					>Filtering landlines or otherwise un-textable numbers will
+					cost $.0025 (1/4 cent) per phone number, but as long as more
+					than a third of your phone numbers are likely to be invalid,
+					it will save you money: It&#39;s cheaper to look up a phone
+					number and throw it out for 1/4 cent than text that number
+					at 1 cent/segment! If you&#39;re pretty sure your phone
+					numbers are valid, feel free to skip this section.
+				</b>
+			</h3><h3>
+				<b
+					>Note: Phone number lookups are charged only once per
+					contact cell for your entire organization. If a contact
+					existed on a previous campaign and the Filter Landlines
+					feature was used, you will not be charged an additional
+					$.0025 to look up the same cell a second time.</b
+				>
+			</h3><br /><p>
+				For more information, see <a
+					href="https://docs.spokerewired.com/article/118-filter-landlines"
+					target="_blank">Filter Landlines</a
+				>.
+			</p><br /><h3>
+				Step 6: Resolve any overlapping contacts with other campaigns
+			</h3><p>
+				If you have uploaded contacts who also appear as contacts within
+				other campaigns, those campaigns are listed in the <b
+					>Contact Overlap Management</b
+				> window. Perform one of the following:
+			</p><ul>
+				<li>
+					Leave the campaign with overlapping contacts in the list.
+				</li><li>
+					Select the overlapping contacts, then click the trash icon
+					to remove those contacts from this new campaign.
+				</li>
+			</ul><br /><p>
+				For more information, see <a
+					href="https://docs.spokerewired.com/article/46-contact-overlap-management"
+					>Contact Overlap Management</a
+				>.
+			</p><br /><h3>Step 7: Optional — Assign teams to the campaign</h3><p
+			>
+				Add teams to the campaign from the <b>Teams</b> window:
+			</p><ol>
+				<li>
+					Click on the <i><b>Select teams</b></i> field and select the
+					team name from the drop down menu.
+				</li><li>
+					<span>Optional</span>— Add additional teams by repeating the
+					previous step.
+				</li><li>
+					<span>Optional</span>— Entirely restrict conversation
+					assignment to members of the listed teams by toggling the
+					switch on. Left off, the assignment will be <span
+						>prioritized
+					</span>for members of those teams but not <span
+						>restricted</span
+					>.
+				</li>
+			</ol><br /><p>
+				For more information about creating a team, see <a
+					href="https://docs.spokerewired.com/article/49-create-a-team"
+					target="_blank">Create a Team</a
+				>.
+			</p><p>
+				When you are finished, click the <i
+					><b>SAVE AND GOTO NEXT SECTION</b></i
+				> button.
+			</p><br /><h3>
+				Step 8: Optional — Set the assignment options for texters
+			</h3><p>
+				Assignment is best done through <a
+					href="https://docs.spokerewired.com/article/111-auto-assignment"
+					>auto-assignment</a
+				> (see Step 10) or through manual assignment within Message Review.
+				However, you have the option to manually assign a number of contacts
+				to an individual texter while building the campaign. To do so:
+			</p><ol>
+				<li>Open the <b>Texters</b> window.</li><li>
+					Search for the names of the texters. The texters must
+					already exist in Spoke.
+				</li><li>
+					Specify the number of contacts to assign to each texter.
+				</li><li>
+					If you have selected multiple texters, you can split the
+					remaining messages by using the <i
+						><b>Split remaining unsent messages</b></i
+					> toggle.
+				</li>
+			</ol><p>
+				When you are finished, click the <b
+					><i>SAVE AND GOTO NEXT SECTION</i></b
+				> button.
+			</p><br /><h3>
+				Step 9: Create an interaction script for your texters
+			</h3><p>
+				To create an interaction script, follow the instructions in <a
+					href="https://docs.spokerewired.com/article/43-create-interaction-script"
+					>Create an Interaction Script</a
+				>.
+			</p><p>
+				When you are finished, click the <i
+					><b>SAVE AND GOTO NEXT SECTION</b></i
+				> button.
+			</p><br /><h3>
+				Step 10: Create canned responses for supplementary FAQ
+			</h3><p>To add a canned response:</p><ol>
+				<li>Open the <b>Canned Responses</b> window.</li><li>
+					Click <i><b>Add new canned response</b></i><b>.</b>
+				</li><li>Enter a title for the canned response.</li><li>
+					Write a script for the response:<ol>
+						<li>Click the <i><b>Script</b></i> field.</li><li>
+							Write your canned response.
+						</li><li>
+							Click <i><b>Done</b></i><span><b>.</b></span>
+						</li>
+					</ol>
+				</li><li>Click <i><b>Add Response</b></i>.</li><li>
+					<span>Optional</span>— Add additional canned responses.
+				</li>
+			</ol><br /><p>
+				For more information, see <a
+					href="https://docs.spokerewired.com/article/47-canned-responses"
+					>Canned Responses</a
+				>.
+			</p><p>
+				When you are finished, click the <i
+					><b>SAVE AND GOTO NEXT SECTION</b></i
+				> button.
+			</p><br /><h3>
+				Step 11: Recommended — Set the auto-assignment option
+			</h3><p>
+				Turning on auto-assignment allows your texters to pick up the
+				assignment automatically from the request form. By default,
+				auto-assignment is turned off.
+			</p><p>To turn on auto-assignment:</p><ol>
+				<li>Open the <b>Autoassign Mode</b> window.</li><li>
+					Turn the toggle on.
+				</li><li>
+					<span>Optional –</span>turn on the toggle to release
+					unhandled replies after a certain period of time and enter
+					the number of minutes in the <i><b>Idle Minutes</b></i> field.
+				</li>
+			</ol><br /><p>
+				For more information, see <a
+					href="https://docs.spokerewired.com/article/111-auto-assignment"
+					>Auto-Assignment</a
+				>.
+			</p><p>
+				When you are finished, click the <i
+					><b>SAVE AND GOTO NEXT SECTION</b></i
+				> button.
+			</p><br /><h3>Step 12: Start the campaign</h3><p>
+				Before you start the campaign, double-check the previous steps
+				to ensure you have properly entered and saved the campaign
+				details. When you are ready to start the campaign, click the <i
+					><b>Start this Campaign</b></i
+				> button in the top right.
+			</p>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-admins/bulk-script-editor.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/bulk-script-editor.astro
@@ -1,0 +1,59 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">Bulk Script Editor</h2>
+
+			<p>
+				The <strong>bulk script editor</strong>is a tool that allows you
+				to simultaneously find and replace parts of your interaction
+				scripts across multiple campaigns. With this tool, you provide
+				the text you want to replace and the text you want to replace it
+				with. The editor searches all campaigns in your organization and
+				performs the replacement for all interaction scripts.&nbsp;
+			</p><p>
+				You can use a filter to restrict the replacement to a smaller
+				set of campaigns. A filter can restrict the editor to active
+				campaigns and to campaigns with names that begin with specific
+				text (this is one reason why having a consistent campaign <strong
+					>naming convention</strong
+				> can be useful).
+			</p><p>
+				To use this tool, you must provide the exact text you want to
+				replace. If your interaction scripts all have slight variations,
+				the bulk script editor must be used for each variation. Keep
+				this in mind when writing interaction scripts.
+			</p><p>
+				If you leave the <strong>"...</strong><strong
+					>with this text"</strong
+				> field blank, the bulk script editor replaces all instances of the
+				text with nothing, effectively deleting them.
+			</p><p>
+				The bulk script editor works only for a single Spoke <a
+					href="https://docs.spokerewired.com/article/79-organizations"
+					>organization</a
+				>. If you have multiple organizations, you must use the bulk
+				script editor for each one.
+			</p><blockquote>
+				Note: Clicking the
+				<strong>Find &amp; Replace</strong> button performs the action without
+				confirmation. Click this button only after you've double-checked
+				the text, filters, and other options.
+				<br />
+			</blockquote><p>
+				After you use the bulk script editor, a notification displays
+				all instances (or occurrences) of replacement. Once you exit
+				this notification, you cannot open it again. If you want to save
+				the details of the replacements, copy them before clicking <strong
+					>OK</strong
+				>.
+			</p>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-admins/campaign-actions.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/campaign-actions.astro
@@ -50,8 +50,8 @@ import "animate.css";
 				action, you should also change the script's initial message so
 				that texters don't send the exact same message twice. For
 				example, you could start the new initial message with, <em
-					>"Hey {firstName}, just wanted to make sure you saw our
-					first message..."&nbsp;</em
+					>"Hey &lcub;firstName&rcub;, just wanted to make sure you
+					saw our first message..."&nbsp;</em
 				>
 			</p><p>
 				When you use this action, a notification displays the number of

--- a/src/pages/docs/spoke/for-spoke-admins/campaign-actions.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/campaign-actions.astro
@@ -1,0 +1,131 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">Campaign Actions</h2>
+
+			<p>
+				You can manage active <a
+					href="https://docs.spokerewired.com/article/25-campaigns"
+					target="_blank">campaigns</a
+				> with campaign actions. The following actions are available for
+				each campaign as viewed on the <strong>Campaigns</strong>page of
+				the administration <a
+					href="https://docs.spokerewired.com/article/52-dashboards"
+					target="_blank">dashboard</a
+				>. You can access these options by clicking the three vertical
+				dots to the right of each campaign.
+			</p><h3>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/5fcad12feb7cc612aa3551cd/file-qbTtSMwLDp.png"
+				/><p>
+					<img
+						src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/5fcae792d580ce55a38b48e1/file-OM7WMNkH6x.png"
+					/>
+				</p>
+			</h3><h3>Release Unsent Messages</h3><h5>
+				Unassigns all conversations waiting for an initial message from
+				a texter.
+			</h5><p>
+				Texters may not all always send out all the initial messages
+				assigned to them. When that happens, you can select&nbsp; <strong
+					>Release Unsent Messages</strong
+				><em>,</em>which will make all previously stranded&nbsp;initial
+				messages available for assignment to other texters via the <a
+					href="https://docs.spokerewired.com/article/110-request-form"
+					target="_blank">request form</a
+				>.
+			</p><h4>Mark For Second Pass</h4><h5>
+				Marks all conversations that didn't receive a response from the
+				contact as needing an initial message.
+			</h5><p>
+				This action is useful for following up with contacts who didn't
+				see the initial message or who forgot to reply. If you use this
+				action, you should also change the script's initial message so
+				that texters don't send the exact same message twice. For
+				example, you could start the new initial message with, <em
+					>"Hey {firstName}, just wanted to make sure you saw our
+					first message..."&nbsp;</em
+				>
+			</p><p>
+				When you use this action, a notification displays the number of
+				conversations that are marked for a second pass. After marking
+				for a pass, you'll need to <strong
+					>Release Unsent Messages
+				</strong>in order to make them available for assignment via the
+				request form. <a
+					href="https://docs.spokerewired.com/article/101-running-a-second-pass"
+					target="_blank">Click here</a
+				> to learn more about running a second pass.
+			</p><blockquote>
+				Note: You can only mark for a second pass before the due date of
+				a campaign.&nbsp;
+			</blockquote><h4>Release Unreplied Conversations</h4><h5>
+				Unassigns conversations where the contact has replied and is
+				awaiting a response from a texter.
+			</h5><p>
+				Texters may not finish responding to all their replies before
+				signing off for the day. Or even if they do, additional replies
+				may continue to come in from the initial message they've already
+				sent. In either case, administrators can <strong
+					>Release Unreplied Conversations
+				</strong>in order to grab those conversations out of their
+				existing workflows and make them available for assignment to
+				other texters via the request form.&nbsp;
+			</p><p>
+				To ensure that you're not ripping away conversations that
+				texters are actively working on, you must specify the amount of
+				time conversations have been idle in order to be released.
+			</p><h4>Archive Campaign</h4><h5>
+				Stops the campaign, marks it as archived, and disables all
+				future texting and notifications for the campaign.
+			</h5><p>
+				Use <strong>Archive Campaign</strong> when you're sure you're&nbsp;done
+				texting on it or if you need to immediately stop all texts from going
+				out to campaign contacts. You can unarchive archived campaigns.&nbsp;
+			</p><h4>Delete Unmessaged Contacts</h4><h5>
+				Removes contacts that have not yet received a message.
+			</h5><p>
+				Use this action if you don't want to message any more contacts
+				on a campaign, but you still want to use auto-assignment to
+				handle replies. For example, you may catch an error in the
+				initial message or realize you've already passed an important
+				deadline. In these scenarios, you won't want to keep
+				sending&nbsp;out incorrect or outdated information, but you'll
+				still need to handle replies from contacts who already received
+				the initial message.
+			</p><h4>Un-Mark for Second Pass</h4><h5>
+				Marks contacts that have been sent a message but are marked as
+				unmessaged&mdash;because they were marked for a second
+				pass&mdash;as having been message.
+			</h5><p>
+				This is effectively an "undo" button for <strong
+					>Mark for Second Pass</strong
+				>. Just as with <strong>Delete Unmessaged Contacts</strong>, you
+				can use this action if you don't want to message any more
+				contacts on a campaign, but you still want to use
+				auto-assignment to handle replies.&nbsp;
+			</p><h4>Turn auto-assign ON/OFF</h4><h5>
+				Makes campaign conversations eligible or ineligible for
+				automatic <a
+					href="https://docs.spokerewired.com/article/33-text-assignment"
+					target="_blank">assignment</a
+				> to texters via the <a
+					href="https://docs.spokerewired.com/article/110-request-form"
+					target="_blank">request form</a
+				>.
+			</h5><p>
+				This is a shortcut action to toggle auto-assignment on or off, <a
+					href="https://docs.spokerewired.com/article/110-request-form"
+					target="_blank">just as you would</a
+				> from the campaign settings page.
+			</p><h5></h5>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-admins/campaign-colors-and-tags.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/campaign-colors-and-tags.astro
@@ -1,0 +1,59 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">Campaign Colors And Tags</h2>
+
+			<p>
+				The campaign list on the administration <a
+					href="https://docs.spokerewired.com/article/52-dashboards"
+					target="_blank">dashboard</a
+				> uses colors and tags to help you keep track of your active campaigns.
+				The colors and tags are automatically applied to the campaigns based
+				on their state.
+			</p><h2>Color Coding</h2><p>
+				Active campaigns in the campaign list are categorized by the
+				color of their titles. They are color-coded as follows:
+			</p><ul>
+				<li>
+					<strong>Orange</strong> -- The campaign has not been started,
+					or it has unassigned contacts.
+				</li>
+				<li>
+					<strong>Blue</strong> -- The campaign has been started but not
+					all initial messages have been sent.
+				</li>
+				<li>
+					<strong>Green</strong> -- The campaign has been started and all
+					initial messages have been sent.
+				</li>
+			</ul><h2>Tags</h2><p>
+				Active campaigns in the campaign list can have one or more of
+				the following tags:
+			</p><ul>
+				<li>
+					<strong>Unassigned Contacts</strong> -- Some contacts have not
+					been assigned to texters.
+				</li>
+				<li>
+					<strong>Unsent Initial Messages</strong> -- Some contacts have
+					not received an initial text.
+				</li>
+				<li>
+					<strong>Unhandled Replies</strong> -- Some contacts have not
+					received a reply from a texter.
+				</li>
+				<li>
+					<strong>Autoassign Eligible</strong> -- The campaign has auto-assignment
+					mode enabled.
+				</li>
+			</ul>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-admins/campaigns.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/campaigns.astro
@@ -1,0 +1,43 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">Campaigns</h2>
+
+			<p>
+				Campaigns are the central feature of Spoke. They provide the
+				structure and tools for <a
+					href="https://docs.spokerewired.com/article/6-user-roles"
+					target="_blank">texters</a
+				> to engage in conversations with your contacts.
+			</p><p>
+				Each campaign has a contact list and an <a href=""
+					>interaction script</a
+				>. When you start a campaign, contacts are assigned to texters,
+				who can then initiate a conversation using the interaction
+				script.&nbsp;
+			</p><p>
+				A campaign should have a clear and specific purpose, for
+				example, asking contacts to attend an event or identifying their
+				level of support for a candidate. This will allow you to
+				communicate clearly with your contacts and for texters to
+				collect consistent data based on how contacts reply.
+			</p><p>
+				You can run multiple campaigns simultaneously to reach different
+				contacts about different things.
+			</p><p>
+				If you are a Spoke administrator, you can manage campaigns from
+				the administration <a
+					href="https://docs.spokerewired.com/article/52-dashboards"
+					target="_blank">dashboard</a
+				>.
+			</p>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-admins/canned-responses.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/canned-responses.astro
@@ -1,0 +1,44 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">Canned Responses</h2>
+
+			<p>
+				Canned responses are an additional set of prepared messages that
+				texters can use if a conversation deviates from the interaction
+				script. They're typically added to prepare texters to answer
+				common questions, for example,"How did you get my number?" or
+				"Will the livestream be recorded?"
+			</p><h5><em>To add canned responses to a campaign:</em></h5><ol>
+				<li>
+					Select the&nbsp;<strong>Canned Responses&nbsp;</strong
+					>window within the campaigns settings page.
+				</li><li>Click <strong>Add New Canned Response.</strong></li><li
+				>
+					Input a <strong>Title</strong> for your canned response.
+				</li><li>
+					Write a <strong>Script</strong> for your canned response and
+					click <strong>Done</strong>.
+				</li><li>Click <strong>Add Response</strong>.</li><li>
+					Repeat steps 2-5 to create additional canned responses.
+				</li><li>Click <strong>Save</strong>.</li>
+			</ol><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/601c91b31f25b9041bebbb72/file-L5cBRPzYFa.png"
+				/>
+			</p><blockquote>
+				Note: Canned responses do not log survey data. If you want to
+				log data associated with a canned response script, it would be
+				better to incorporate that script as a survey option or tag.<br
+				/>
+			</blockquote>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-admins/change-user-roles.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/change-user-roles.astro
@@ -1,0 +1,41 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">Change User Roles</h2>
+
+			<p>
+				User roles can be changed from the
+				<strong>People</strong> page of the administration&nbsp;dashboard.
+				After you <a
+					href="https://docs.spokerewired.com/article/65-invite-texters-to-spoke"
+					target="_blank">invite texters</a
+				> to join your Spoke organization and they create an account, they
+				will automatically be listed with the default <strong
+					>Texter</strong
+				> role.
+			</p><h5><em>To change a user's role:</em></h5><ol>
+				<li>
+					Navigate to the <strong>People</strong>page within
+					the&nbsp;administration <a href="" target="_blank"
+						>dashboard</a
+					>.
+				</li>
+				<li>Click "Texter" to reveal a dropdown menu of roles.</li>
+				<li>
+					Select a new role. For more information about the different
+					user roles, see <a
+						href="https://docs.spokerewired.com/article/6-user-roles"
+						target="_blank">user roles</a
+					>.
+				</li>
+			</ol>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-admins/contact-lists.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/contact-lists.astro
@@ -61,10 +61,9 @@ import "animate.css";
 					href="https://docs.spokerewired.com/article/38-interaction-scripts"
 					>interaction script</a
 				>. Just as with the <b>firstName</b> field, these values will dynamically
-				populate in your script for each contact. An example of this is {
-					polling_location
-				}, where each contact may have their specific polling location
-				appended.
+				populate in your script for each contact. An example of this is &lcub;
+				polling_location &rcub;, where each contact may have their specific
+				polling location appended.
 			</p><h2><b>Uploading a Contact List</b></h2><p>
 				You can upload contact lists from the campaign settings page.
 				Click the <b>Contacts</b> window and then either:

--- a/src/pages/docs/spoke/for-spoke-admins/contact-lists.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/contact-lists.astro
@@ -1,0 +1,175 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">Contact Lists</h2>
+
+			<p>
+				Every campaign requires a contact list, which provides the full
+				set of people you wish to contact with that campaign. If loading
+				contacts via a file rather than a <a
+					href="https://docs.spokerewired.com/article/93-van-list-loading"
+					>VAN integration</a
+				>, you must provide the contact list in a <b
+					>comma separated values (CSV) format</b
+				>.
+			</p><p>
+				Once uploaded to the campaign, Spoke maintains an internal
+				version of the list and modifies it as the campaign progresses.
+				You can export the modified contact list for your own record
+				keeping. For more information, see <a
+					href="https://docs.spokerewired.com/article/71-export-data-from-a-campaign"
+					>Export Data from a Campaign</a
+				>.
+			</p><h2><b>CSV Files</b></h2><h4><b>Column Headers</b></h4><p>
+				If loading your contact list as a file, your list should be a
+				comma separated values (CSV) file with the following column
+				headings in the first row:
+			</p><ul>
+				<li>
+					<b>firstName</b>— <span>Required</span> — First names of your
+					contacts.
+				</li><li>
+					<b>lastName</b>— <span>Required</span>— Last names of your
+					contacts.
+				</li><li>
+					<b>cell</b>— <span>Required</span>— Cell number of your
+					contacts<b>.</b>
+				</li><li>
+					<b>zip</b>—<span> Recommended</span>— Zip code of your
+					contacts. The zip code is used to estimate your
+					contact&#39;s timezone and allow texters to have
+					conversations with them at the appropriate time.
+				</li><li>
+					<b>external_id</b> — <span>Recommended</span> — ID to map your
+					contacts to a CRM. This value is often made up of VAN IDs.
+				</li>
+			</ul><p>
+				Note:  The <b> firstName</b>and <b>lastName</b>fields will be
+				automatically capitalized for all values other than common
+				placeholders for unknown names: &quot;friend&quot; and
+				&quot;there&quot;.
+			</p><h4><b>Custom Fields</b></h4><p>
+				You have the option to include additional custom fields in the
+				contact list. You can use these fields in the campaign&#39;s <a
+					href="https://docs.spokerewired.com/article/38-interaction-scripts"
+					>interaction script</a
+				>. Just as with the <b>firstName</b> field, these values will dynamically
+				populate in your script for each contact. An example of this is {
+					polling_location
+				}, where each contact may have their specific polling location
+				appended.
+			</p><h2><b>Uploading a Contact List</b></h2><p>
+				You can upload contact lists from the campaign settings page.
+				Click the <b>Contacts</b> window and then either:
+			</p><ol>
+				<li>Click <b>Select a File</b>or</li><li>
+					Drag and drop the file into the dotted-line rectangle
+				</li>
+			</ol><p>
+				<img
+					src="https://lh4.googleusercontent.com/EfxgdyBzzn2Hl-ELdAzXlIdA0TuXOxcPb6mRJ9lwJuDqA9haWwRAyv7oI2C7oSsSZQH1HHnHDnOub9DXdCMD1a4O8DH-O8-g2HMdqHjd1hKkQ1pcwhR-LfxeFiraiPleXauMWJASB4bl_ucmvF7uhS4"
+					style="max-width: 100%; "
+				/>
+			</p><ol start="3">
+				<li>
+					After uploading a csv file, a popup menu will appear
+					allowing you to map the column headers of your csv to the
+					required column headers (First Name, Last Name, and Cell
+					Phone), as well as map the optional headers (Zip and
+					External ID).
+				</li>
+			</ol><p style="text-align: center;" class="align-center">
+				<img
+					src="https://lh5.googleusercontent.com/Xfv5mgVxggIXqrYWB50eLEKd1eE6JCyMufIo7x_-VLf70PPhyfHWxbR0C3wfXFJkr7IUd7I_ecp_4kr3bPThu4FcSCSKadRNPgjfey_caH-bZA4DUomo9JN_imKGqey3B794F2PWsJGrIZ6XEGCo22U"
+					style="max-width: 100%; text-align: center;"
+				/>
+			</p><p style="text-align: center;" class="align-center">
+				<img
+					src="https://lh5.googleusercontent.com/17hMw0YzflF7ln_klrxQzqRPlgHQwl_kCiGwP_EzZbN3dPRIDhmPy2qPpGa8Rm4oZsve3ORGGWunrja1ZZWvylDjZhLdL_WuKYVAbx8LLYS-D5IjFH6_Wy57qnbFho7nsyS8G-BywJVIwcFqnuB3xiE"
+					style="max-width: 100%; text-align: center;"
+				/>
+			</p><p>
+				Then hit <b>Save.</b> The name of your csv will now appear in the
+				file upload box with a green background, indicating a successful
+				upload.
+			</p><p>
+				Note: You can use the <b>Configure Column Mapping</b> button to open
+				the popup again and update the mappings you chose.
+			</p><p>
+				<img
+					src="https://lh6.googleusercontent.com/zpGMQ74h9RiFV_2l5FPgbaexgXXAdrC70zuV-F3rMCQtr0-3_3lGIENxplmeWsTXqVZ19bwHX8r7BpQr0XAibcKpKnYgCJBnRnazHzHfglEsfnio03iDPNyih9-J_oBNrMQh9O5hPButF31WOddYXz0"
+					style="max-width: 100%; "
+				/>
+			</p><p>
+				<span>Optional</span> — Exclude contacts who also appear as contacts
+				within another campaign using the drop down menu.
+			</p><p>
+				<img
+					src="https://lh5.googleusercontent.com/PjL4c34dSxex9bUAgT_YATRktpVkPuxQXQ7dAtIl8ZsrByfiZ5pYvgDNqJax6xYEVA8Z5Zv1vds3lvj5p5Su6HT9X724r3-l7cFrLl46M2x3Nlw2KUgBM2hC2hItRI1uJji_Pp10fAlhBIjgEFm2PWE"
+					style="max-width: 100%; "
+				/>
+			</p><ol>
+				<li>
+					Start typing the name of the campaign you want to use for
+					filtering (or open the drop-down menu).
+				</li><li>Click the campaign name in the list.</li><li>
+					Repeat until you&#39;ve finished adding the campaigns you
+					want to exclude.
+				</li>
+			</ol><h4>List Processing</h4><p>
+				When you upload a contact list, Spoke performs two rounds of
+				processing. The first round, which happens in the Spoke
+				application, handles the following:
+			</p><ul>
+				<li>
+					The removal of duplicate contacts (duplicates are determined
+					based on phone number; the first instance is kept).
+				</li><li>The removal of contacts without phone numbers.</li><li>
+					The removal of contacts with invalid phone numbers.
+				</li>
+			</ul><p>
+				After you click <b>Save</b>, the second round of processing
+				handles the following:
+			</p><ul>
+				<li>The removal of all contacts that have opted out.</li><li>
+					The removal of all contacts from campaigns that you
+					specified in <span>Filter Existing Campaigns</span> (see below).
+				</li>
+			</ul><p>
+				Any automated handling of your contact list is detailed in the
+				upload report. You can view the upload report from the contacts
+				window of the campaign settings page.
+			</p><p>
+				Note: If you upload another contact list, it removes all
+				previously uploaded contacts and replaces them with the most
+				recent contact list. This is true up until the point that your
+				campaign is started, after which you will no longer be able to
+				modify the contact list.
+			</p><h4><b>Filtering Existing Campaigns</b></h4><p>
+				You can choose to filter contacts who already exist as contacts
+				within another campaign. This helps you prevent sending too many
+				messages to a contact or sending redundant information from two
+				similar campaigns.
+			</p><p>
+				To use this feature, enter the names of the campaigns that are
+				used to filter out contacts. You can enter multiple campaign
+				names at once. <b
+					>This step must be done before loading the CSV.</b
+				>
+			</p><p>
+				You can also achieve the same function of eliminating overlap
+				with previous campaigns by using <a
+					href="https://docs.spokerewired.com/article/46-contact-overlap-management"
+					>Contact Overlap Management</a
+				>.
+			</p>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-admins/contact-overlap-management.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/contact-overlap-management.astro
@@ -1,0 +1,86 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">Contact Overlap Management</h2>
+
+			<p>
+				When you <a
+					href="https://docs.spokerewired.com/article/64-contact-lists"
+					target="_blank">upload a contact list</a
+				> to a new campaign, Spoke automatically detects overlapping contacts
+				with previous campaigns. <strong
+					>Contact Overlap Management</strong
+				> allows you to review and delete these overlapping contacts so that
+				you can avoid&nbsp;interrupting existing conversations and not over-text
+				your contacts.&nbsp;Typically, it's best to delete overlapping contacts
+				from recent campaigns.
+			</p><p>
+				For each previous campaign listed in the&nbsp;Contact Overlap
+				Management window, you'll see:
+			</p><ul>
+				<li>
+					<strong>Overlap Count:</strong>&nbsp;the number of
+					overlapping contacts between the previous campaign and new
+					campaign
+				</li>
+
+				<li>
+					<strong>ID:</strong>&nbsp;the ID number of the previous
+					campaign
+				</li>
+
+				<li>
+					<strong>Last Message:</strong>&nbsp;the last time at least
+					one overlapping contact was messaged&nbsp;
+				</li>
+
+				<li>
+					<strong>Title:&nbsp;</strong>the name of the previous
+					campaign
+				</li>
+			</ul><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/601c858d1f25b9041bebbb40/file-Ps0feQyFOu.png"
+				/>
+			</p><h5>
+				<em>To identify and delete overlapping contacts:</em>
+			</h5><ol>
+				<li>
+					Select the&nbsp;<strong>Contact Overlap Management</strong> window
+					within the campaigns settings page.
+				</li>
+
+				<li>
+					Review the campaigns that have overlapping contacts with the
+					new campaign.
+				</li>
+
+				<li>
+					Click the checkboxes that correspond to the rows of
+					overlapping contacts you wish to delete.
+				</li>
+
+				<li>Click <strong>Delete Selected</strong>.</li>
+			</ol><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/601c8627ac2f834ec538594d/file-JyAoBdI2k4.png"
+				/>
+			</p><blockquote>
+				Note: Different campaigns may text contacts from the same
+				number, which means that from the contact's perspective, the two
+				conversation will be taking place in the same text thread. This
+				can be confusing and undermine the efficacy of both campaigns,
+				which is why it's a very good idea to delete overlapping
+				contacts from recent campaigns.
+				<br />
+			</blockquote>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-admins/copy-a-campaign.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/copy-a-campaign.astro
@@ -1,0 +1,46 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">Copy A Campaign</h2>
+
+			<p>
+				You can copy an existing campaign as a way to create a new
+				campaign with the same or a similar
+				<a
+					href="https://docs.spokerewired.com/article/38-interaction-scripts"
+					target="_blank">interaction script</a
+				>. This is often the faster and easier way to create a new
+				campaign.
+			</p><h5>
+				<em>To copy a campaign:</em>
+			</h5><p>
+				1. Select the campaign you wish to copy from the
+				<strong>Campaigns</strong>&nbsp;page of the administration <a
+					href="https://docs.spokerewired.com/article/52-dashboards"
+					target="_blank">dashboard</a
+				>.
+			</p><p>
+				2. Click the&nbsp;
+				<strong>Copy Campaign</strong>button. You should see a pop-up
+				message stating that the campaign successfully copied.
+			</p><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/600731becfe30d219ccd950b/file-VCiSnprHnm.png"
+					alt=""
+					style="display: block; margin: auto;"
+				/>
+			</p><p>
+				Your copied campaign will then appear at the bottom of your
+				<strong>Campaigns</strong>page with the word "COPY" at the start
+				of the campaign title.
+			</p>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-admins/copy-block.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/copy-block.astro
@@ -1,0 +1,89 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">Copy Block</h2>
+
+			<p>
+				When you're
+				<a
+					href="https://docs.spokerewired.com/article/43-create-interaction-script"
+					target="_blank">creating an interaction script</a
+				> for your campaign, you can easily copy and paste script blocks
+				within or between campaigns. This can be helpful if you want to add
+				generic survey scripts you already have written elsewhere (e.g.,
+				Wrong Number) or if you're building multiple complex survey trees
+				within a single campaign, each with the same or similar structure
+				and content.
+			</p><h5><em>To copy and paste a script block:</em></h5><p>
+				1. Navigate to the campaign that contains the script block you
+				wish to copy.
+			</p><p>
+				2. Open the
+				<strong>Interactions</strong>window&nbsp;within the campaign
+				settings page.
+			</p><p>
+				3. Click the
+				<strong>Copy Block</strong>button within the script block you
+				wish to copy.
+			</p><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/604be58bc44f5d025f443a12/file-H9XdpUzycG.png"
+				/>
+			</p><p>
+				4. Navigate to the campaign within which you want to paste the
+				copied block. If you're copying and pasting in the same
+				campaign, just stay where you are!
+			</p><p>
+				5. Find the survey question that your copied block will be
+				answering and click the&nbsp;<strong
+					>+ Paste Block
+				</strong>button immediately underneath the script block that
+				contains the survey question. The copied script block will
+				appear immediately below the survey question.
+			</p><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/604be5cf24ce107ab4d151d1/file-tmOb5i9mfK.png"
+				/>
+			</p><blockquote>
+				Note #1: You can copy and paste entire survey trees (i.e., a
+				script block with a survey question and all the the script
+				blocks with survey answers nested underneath it) by copying the
+				parent script block containing the survey question. When you
+				paste the block, it will cary over not only the parent script
+				block, but also all of its "children" blocks nested beneath it.
+			</blockquote><blockquote>
+				<em style="background-color: initial;"
+					>Note #2: If you wish to replace the entire Interactions
+					script with that of another campaign, first click <strong
+						>Copy Block
+					</strong>on the initial message of the campaign you want to
+					copy, then select&nbsp;</em
+				><em style="background-color: initial;"
+					><strong>+ Paste Block</strong>within the initial message
+					script block of the campaign you want to replace. You may
+					also want to consider simply</em
+				>
+				<a
+					href="https://docs.spokerewired.com/article/112-copy-a-campaign"
+					target="_blank">making a copy</a
+				>
+				<em style="background-color: initial;"
+					>of the campaign you wish to replicate.<br />
+				</em>
+			</blockquote><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/604be6d1c44f5d025f443a16/file-HlNKU0Ye6O.png"
+				/><img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/604be740207e3b1188e1bbb3/file-rIpR8C5IaN.png"
+				/>
+			</p>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-admins/create-a-team.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/create-a-team.astro
@@ -1,0 +1,55 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">Create A Team</h2>
+
+			<p>
+				Teams allow you to group the texters in your organization so
+				that you can delegate specific texting campaigns to specialized
+				subsets of texters. For example, you may want to to create a
+				Spanish Team for Spanish texting campaigns or a Persuasion Team
+				for persuasion texting campaigns.
+			</p><h5><em> To create a team:</em></h5><ol>
+				<li>
+					From the administration <a
+						href="https://docs.spokerewired.com/article/52-dashboards"
+						target="_blank">dashboard</a
+					>, navigate to the <strong>Teams</strong>page.
+				</li>
+				<li>
+					Click the green&nbsp;<strong>plus (+)&nbsp;</strong>button
+					in the bottom right-hand corner.
+				</li>
+				<li>Enter a team name.</li>
+				<li>Enter a team description.</li>
+				<li>
+					Enter an assignment priority value for the team. The lower
+					the number, the higher the priority (i.e., those
+					team-specific campaigns will be assigned first).
+				</li>
+				<li>Click <strong>Create</strong>.</li>
+			</ol><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/601d9fd96867724dfc6f0349/file-NqxngimBVP.png"
+				/>
+			</p><h5><em> To add texters to a team:</em></h5><ol>
+				<li>Select the team from the team list.</li>
+				<li>
+					Enter a texter's name in the <strong>Add Texter</strong> field.
+				</li>
+				<li>Select the name from the list.</li>
+			</ol><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/601da01ffb34b55df443ddec/file-jxfKrmWYbw.png"
+				/>
+			</p>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-admins/create-interaction-script.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/create-interaction-script.astro
@@ -1,0 +1,126 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">Create Interaction Script</h2>
+
+			<p>
+				The interaction&nbsp;script is where you determine the structure
+				and message of your campaign.
+			</p><h4><em>To create an interaction script:</em></h4><p>
+				1. Select your campaign from the <strong>Campaign</strong> page of
+				the administration <a
+					href="https://docs.spokerewired.com/article/52-dashboards"
+					target="_blank">dashboard</a
+				>.
+			</p><p>
+				2. Select the <strong>Interactions</strong>window from the
+				campaign settings page.
+			</p><p>
+				3. Write an initial message that will be sent to all of your
+				campaign contacts:
+			</p><ul>
+				<li>
+					Click the&nbsp;<strong>Script Version 1&nbsp;</strong>field.
+				</li>
+				<li>
+					Enter an initial message; use dynamic script as appropriate,
+					for example, you may want to begin with something like, "Hi {
+						firstName
+					}, it's {texterFirstName} with..." As of 2022, you will need
+					to include opt out language like "<strong
+						>Reply STOP to opt out</strong
+					>" at the end of your message to ensure
+					deliverability.&nbsp;
+				</li>
+				<li>Click&nbsp;<strong>Done</strong>.</li>
+				<li>
+					Click the <strong>Question</strong> field and write a survey
+					question. You must have a survey question to add survey responses.
+					Only texters can see the survey question.
+				</li>
+			</ul><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/62ffaeab502e69288e0e159f/file-RB0IQBC4nR.png"
+				/>
+			</p><p>
+				4. Create survey responses for your texters to navigate their
+				conversations:
+			</p><ul>
+				<li>Click the&nbsp;<strong>Add a Response</strong>button.</li>
+				<li>
+					Click the <strong>Answer</strong>field and write an answer
+					to your previous survey question. Texters will be able to
+					select this survey answer to log data and access the
+					prepared response script. Only texters see the survey answer
+					itself; contacts will only see the script.
+				</li>
+				<li>
+					Click the&nbsp;<strong>Script Version 1</strong>&nbsp;field.
+				</li>
+				<li>
+					Enter a survey response script that will automatically
+					populate when a texter selects the survey answer.&nbsp;
+				</li>
+				<li>Click&nbsp;<strong>Done</strong>.</li>
+				<li>
+					If you include an additional question in your survey
+					response script, you can add a new survey question by
+					clicking the <b style="background-color: initial;"
+						>Question
+					</b>field and writing a new question.
+				</li>
+			</ul><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/601c8b0f1f25b9041bebbb5e/file-zmUrlcXvrX.png"
+				/>
+			</p><p>
+				5. Repeat step 4, adding survey responses to the question posed
+				in your initial message. If you include additional questions
+				under these survey response, make sure to add survey responses
+				nested under those questions as well.
+			</p><p>
+				6. Click&nbsp; <strong>Save</strong>.&nbsp;
+			</p><blockquote>
+				Note #1: When building campaigns with multiple survey questions,
+				make sure you are adding responses under the appropriate
+				question. You can use
+				<a
+					href="https://docs.spokerewired.com/article/114-script-preview"
+					target="_blank"
+					style="font-style: italic;">Script Preview</a
+				> to double-check your work and easily view your question and response
+				trees.
+			</blockquote><blockquote>
+				<em style="background-color: initial;"
+					>Note #2: You are able to write multiple versions of any
+					survey script; these are then randomly distributed across
+					conversations. This can be a way to a/b test different
+					messages or to minimize the chance your texts are flagged as
+					spam by cell carriers<br />
+				</em>
+			</blockquote><blockquote>
+				<em style="background-color: initial;"
+					>Note # 3:&nbsp;When writing a script, you can see the
+					estimated number of segments per text message, as well&nbsp;</em
+				>
+				<em style="background-color: initial;"
+					>as the number of characters left in the current segment.
+					This can help you estimate the&nbsp;</em
+				>
+				<a href="https://politicsrewired.com/pricing/">cost</a>
+				<em style="background-color: initial;">of your campaign.</em>
+			</blockquote><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/601c9996a4cefb30ae5c7a48/file-A5QXqh1cqv.png"
+				/>
+			</p>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-admins/create-interaction-script.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/create-interaction-script.astro
@@ -31,13 +31,11 @@ import "animate.css";
 				</li>
 				<li>
 					Enter an initial message; use dynamic script as appropriate,
-					for example, you may want to begin with something like, "Hi {
-						firstName
-					}, it's {texterFirstName} with..." As of 2022, you will need
-					to include opt out language like "<strong
-						>Reply STOP to opt out</strong
-					>" at the end of your message to ensure
-					deliverability.&nbsp;
+					for example, you may want to begin with something like, "Hi
+					&lcub; firstName &rcub;, it's &lcub;texterFirstName&rcub;
+					with..." As of 2022, you will need to include opt out
+					language like "<strong>Reply STOP to opt out</strong>" at
+					the end of your message to ensure deliverability.&nbsp;
 				</li>
 				<li>Click&nbsp;<strong>Done</strong>.</li>
 				<li>

--- a/src/pages/docs/spoke/for-spoke-admins/dashboards.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/dashboards.astro
@@ -1,0 +1,142 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">Dashboards</h2>
+
+			<p>
+				Dashboards are the primary interfaces that administrators and
+				texters use to navigate Spoke.
+			</p><h2>Administration Dashboard</h2><p>
+				The administration dashboard lets you manage your Spoke <a
+					href="https://docs.spokerewired.com/article/79-organizations"
+					>organization</a
+				>. From the administration dashboard, you can access the
+				following pages:
+			</p><ul>
+				<li>
+					<strong>Campaigns:</strong>a list of active campaign. Where
+					you can <a
+						href="https://docs.spokerewired.com/article/34-create-a-campaign"
+						target="_blank">create</a
+					> new campaigns, view campaigns <a
+						href="https://docs.spokerewired.com/article/57-colors-and-tags-for-active-campaigns"
+						target="_blank">statuses</a
+					>, and take campaign <a
+						href="https://docs.spokerewired.com/article/59-campaign-actions"
+						target="_blank">actions</a
+					>.
+				</li>
+				<li>
+					<strong>Template Campaigns:</strong> a list of template campaigns.
+					Where you can <a
+						href="https://docs.spokerewired.com/article/164-template-campaigns"
+						target="_blank">create and edit template campaigns</a
+					>.
+				</li>
+				<li>
+					<strong>People:</strong>a list of Spoke users. Where you can <a
+						href="https://docs.spokerewired.com/category/42-administering-spoke"
+						target="_blank">invite</a
+					> users to Spoke and <a
+						href="https://docs.spokerewired.com/article/35-change-user-roles"
+						target="_blank">change</a
+					> user roles.
+				</li>
+				<li>
+					<strong>Teams:</strong> a list of texter teams. Where you can
+					<a
+						href="https://docs.spokerewired.com/article/49-create-a-team"
+						target="_blank">create</a
+					> and edit teams.
+				</li>
+				<li>
+					<strong>Assignment Control:</strong>
+					<a
+						href="https://docs.spokerewired.com/article/66-manage-assignment-control"
+						target="_blank">control panel</a
+					> for the request form. Where you can distribute texting assignments
+					to texters.
+				</li>
+				<li>
+					<strong>Tags:</strong>a list of <a
+						href="https://docs.spokerewired.com/article/67-conversation-tags"
+						target="_blank">conversation tags</a
+					>. Where you can add new tags and edit existing tags.
+				</li><li>
+					<strong>Opt Outs:</strong>Where you can&nbsp;import or
+					export opt outs or import opt ins.
+				</li>
+				<li>
+					<strong>Message Review:</strong> conversation filtering and assignment
+					interface. Where you can filter conversations to find specific
+					messages or analyze campaigns; where you can bulk <a
+						href="https://docs.spokerewired.com/article/63-reassign-conversations-to-texters"
+						target="_blank">reassign</a
+					> or unassign conversations.
+				</li>
+				<li>
+					<strong>Escalated Convos:</strong>workflow of escalated
+					conversations. Where you can review escalated messages.
+				</li>
+				<li>
+					<strong>Bulk Script Editor:</strong>&nbsp;Find-and-replace
+					tool. Where you can make <a
+						href="https://docs.spokerewired.com/article/69-bulk-script-editor"
+						target="_blank">bulk script edits</a
+					> across multiple campaigns.
+				</li>
+				<li>
+					<strong>Assignment Requests:</strong>Queue of pending texter
+					assignment requests. Where you can manually approve
+					assignment requests from texters (only relevant if you're <em
+						>not</em
+					>&nbsp;using auto-assign)
+				</li>
+				<li>
+					<strong>Integrations:</strong>List of Spoke integrations.
+					Where you can set up a <a
+						href="https://docs.spokerewired.com/article/93-van-list-loading"
+						target="_blank">VAN integration</a
+					>.
+				</li>
+				<li>
+					<strong>Settings</strong>: Menu of <a
+						href="https://docs.spokerewired.com/article/78-settings"
+						target="_blank">settings</a
+					>.
+				</li>
+			</ul><p>
+				You must be an <a
+					href="https://docs.spokerewired.com/article/6-user-roles"
+					target="_blank">Administrator or Owner</a
+				> for your Spoke organization to use the administration dashboard.
+				To access the administration dashboard, use the following URL:&nbsp;
+			</p><p>
+				<a href="https://your-domain.spokerewired.com/admin/1/campaigns"
+					>https://your-domain.spokerewired.com/admin/1/campaigns</a
+				>
+			</p><p>
+				Where&nbsp;<em>your-domain&nbsp;</em>is the unique subdomain
+				name you chose when signing up.
+			</p><h2>Texter Dashboard</h2><p>
+				The texter dashboard lets you request texts and send messages to
+				any conversations assigned to you. You must have a user account
+				with your Spoke organization to use the texter dashboard.
+			</p><p>To access the texter dashboard, use the following URL:</p><p>
+				<a href="https://your-domain.spokerewired.com/app/1"
+					>https://your-domain.spokerewired.com/app/1</a
+				>
+			</p><p>
+				Where&nbsp;<em>your-domain&nbsp;</em>is the unique subdomain
+				name you chose when signing up.
+			</p>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-admins/data-dictionary.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/data-dictionary.astro
@@ -1,0 +1,232 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">Data Dictionary</h2>
+
+			<h4>
+				The following table is designed to help you better understand
+				the data from your texting campaigns, allowing you to analyze
+				campaign performance. Sample scripts for potential analyses can
+				be found below the table. Depending on the platform you use, you
+				may need to adjust schema prefixes (e.g. &quot;message&quot; may
+				need to become &quot;spoke.message&quot;).
+			</h4><table>
+				<thead>
+					<tr>
+						<th style="text-align:left;"> title</th>
+						<th style="text-align:left;"> description</th>
+						<th> key columns</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td style="text-align:left;"> campaign</td>
+						<td style="text-align:left;">
+							Contains information about each campaign - e.g. when
+							it was created or whether it was archived. Primary
+							key is campaign.id.
+						</td>
+						<td> &nbsp;</td>
+					</tr>
+					<tr>
+						<td style="text-align:left;"> campaign_contact</td>
+						<td style="text-align:left;">
+							Contains information about a contact for each
+							campaign. Joins to campaign on
+							campaign_contact.campaign_id = campaign.id. Primary
+							key is campaign_contact.id.
+						</td>
+						<td> &nbsp;</td>
+					</tr>
+					<tr>
+						<td style="text-align:left;"> message</td>
+						<td style="text-align:left;">
+							Contains each message, inbound and outbound. Joins
+							to campaign and campaign_contact on
+							message.campaign_contact_id = campaign_contact.id.
+						</td>
+						<td>
+							is_from_contact = true means message is inbound, =
+							false means outbound message
+						</td>
+					</tr>
+					<tr>
+						<td style="text-align:left;"> question_response</td>
+						<td style="text-align:left;">
+							Contains "question responses," or Spoke question
+							responses. Joins to campaign and campaign_contact on
+							question_response.campaign_contact_id =
+							campaign_contact.id. Only includes contacts who have
+							a question_response populated.
+						</td>
+						<td>
+							'value' contains question response values like
+							support score, activist codes, Wrong Number, etc.
+						</td>
+					</tr>
+					<tr>
+						<td style="text-align:left;"> all_question_response</td>
+						<td style="text-align:left;">
+							Contains "question responses", or Spoke question
+							responses. Joins to campaign and campaign_contact on
+							question_response.campaign_contact_id =
+							campaign_contact.id. Includes all contacts,
+							including those who did not respond, where the
+							"value" is null.
+						</td>
+						<td> &nbsp;</td>
+					</tr>
+					<tr>
+						<td style="text-align:left;"> canned_response</td>
+						<td style="text-align:left;">
+							Contains all Spoke canned responses.
+						</td>
+						<td> &nbsp; &nbsp;</td>
+					</tr>
+					<tr>
+						<td style="text-align:left;"> interaction_step</td>
+						<td style="text-align:left;">
+							Contains all of the scripts at each 'interaction
+							step' in the texting script, as well as the
+							hierarchy for how all of the 'interaction steps' in
+							the texting script tree are related to one another.
+						</td>
+						<td> &nbsp;</td>
+					</tr>
+					<tr>
+						<td style="text-align:left;"> opt_out</td>
+						<td style="text-align:left;">
+							Contains all opted out contacts, as well as the
+							campaigns on which they were opted out.
+						</td>
+						<td> &nbsp;</td>
+					</tr>
+					<tr>
+						<td style="text-align:left;"> campaign_contact_tag</td>
+						<td style="text-align:left;">
+							Campaign contacts and associated tags. Must be
+							joined back to all_tag or tag on
+							campaign_contact_tag.tag_id = all_tag.id to get tag
+							titles.
+						</td>
+						<td> &nbsp;</td>
+					</tr>
+					<tr>
+						<td style="text-align:left;"> all_tag</td>
+						<td style="text-align:left;">
+							Contains all tags, including those which have been
+							deleted.
+						</td>
+						<td> &nbsp;</td>
+					</tr>
+					<tr>
+						<td style="text-align:left;"> tag</td>
+						<td style="text-align:left;">
+							A view of all_tag for tags that have not been
+							deleted.
+						</td>
+						<td> &nbsp;</td>
+					</tr>
+					<tr>
+						<td style="text-align:left;"> user</td>
+						<td style="text-align:left;">
+							Contains information about users (texters,
+							supervolunteers, admins, owners).
+						</td>
+						<td> &nbsp;</td>
+					</tr>
+					<tr>
+						<td style="text-align:left;"> team</td>
+						<td style="text-align:left;">
+							Contains team ID and team title for texting teams
+							you may have within your organization.
+						</td>
+						<td> &nbsp;</td>
+					</tr>
+					<tr>
+						<td style="text-align:left;"> user_team</td>
+						<td style="text-align:left;">
+							Crosswalk between team and user.
+						</td>
+						<td> joins to team on team.id = user_team.team_id</td>
+					</tr>
+					<tr>
+						<td style="text-align:left;"> user_organization</td>
+						<td style="text-align:left;">
+							Crosswalk between user and organization.
+						</td>
+						<td> &nbsp;</td>
+					</tr>
+					<tr>
+						<td style="text-align:left;"> organization</td>
+						<td style="text-align:left;">
+							Lists all organizations within your instance of
+							Spoke. For example, you might have different
+							organizations if there are multiple sub-groups /
+							affiliates of a larger organization using your
+							Spoke.
+						</td>
+						<td>
+							joins to campaign on organization.id =
+							campaign.organization_id
+						</td>
+					</tr>
+				</tbody>
+			</table><h3>Sample Scripts</h3><p>
+				How to get <strong
+					>counts of contacts with certain tags within a certain
+					interval</strong
+				>:
+			</p><pre><p>select at.title, count(distinct cc.id)  from campaign_contact cc</p><p>left join campaign_contact_tag cct on cc.id = cct.campaign_contact_id</p><p>left join all_tag at on cct.tag_id = at.id</p><p>where cct.updated_at between now() - interval &#39;12 hours&#39; and now()</p><p>group by at.title</p><br /></pre><p
+			>
+				How to get an <strong>export ready for VAN bulk upload</strong>,
+				marking null values as &#39;canvassed, no response&#39;:
+			</p><pre><p>select distinct cc.external_id,</p><p>                case when aqr.value is null then &#39;canvassed, no response&#39;</p><p>                     else aqr.value end as value,</p><p>                to_char(m.sent_at,&#39;MM-DD-YYYY&#39;) as date from campaign c</p><p>left join campaign_contact cc on c.id = cc.campaign_id</p><p>left join message m on cc.id = m.campaign_contact_id</p><p>left join all_question_response aqr on cc.id = aqr.campaign_contact_id</p><br /></pre><p
+			>
+				How to find the <strong
+					>number of texts sent inbound and outbound</strong
+				>, grouped by day:
+			</p><p>
+				<em>edit timezone to reflect your timezone</em>
+			</p><pre><p>select   date(sent_at::timestamptz at time zone &#39;EDT&#39;) as date, </p><p>         case </p><p>                  when is_from_contact = true then &#39;inbound&#39; </p><p>                  when is_from_contact = false then &#39;outbound&#39; </p><p>         end      as direction, </p><p>         Count(*) as messages </p><p>from     message </p><p>group by date(sent_at::timestamptz at time zone &#39;EDT&#39;), </p><p>         is_from_contact </p><p>order by date(sent_at::timestamptz at time zone &#39;EDT&#39;) desc;</p><br /></pre><p
+			>
+				How to find <strong
+					>number of texts sent by a member of a certain team</strong
+				> (i.e. &quot;Spanish texting team&quot;)
+			</p><pre><p>select Count(*) </p><p>from   message </p><p>where  user_id in </p><p>       ( </p><p>              select user_id </p><p>              from   user_team </p><p>              join   team </p><p>              on     team.id = user_team.team_id </p><p>              where  team.title ilike &#39;%spanish%&#39; );</p><br /></pre><p
+			>
+				How to find <strong>number of unique texters</strong> in your
+				organization:
+			</p><pre><p>select count(*) from user;</p><br /></pre><p>
+				How to calculate <strong>response rates</strong>
+				<strong>by script option</strong> for Campaign ID 75, <strong
+					>for initial text only:</strong
+				>
+			</p><pre><p>-- Your analysis on messages, grouped by the script_option_hash</p><p>-- replace campaign_id with actual campaign ID</p><p>with hash_counts as (</p><p>  select</p><p>    campaign_id,</p><p>    script_version_hash,</p><p>    count(*) as hash_count</p><p>  from message</p><p>  join campaign_contact</p><p>    on campaign_contact.id = message.campaign_contact_id</p><p>  where</p><p>    campaign_id = 75</p><p>  group by 1, 2</p><p>),</p><p>-- Fetch script options as reference</p><p>scripts as (</p><p>  select</p><p>    interaction_step.id as istep_id,</p><p>    interaction_step.campaign_id,</p><p>    unnest(interaction_step.script_options) as script_option</p><p>  from interaction_step</p><p>  where campaign_id = 75</p><p>-- EDITING HERE WILL CHANGE the &#39;interaction_step&#39; parent, and for initial texts, the </p><p>-- interaction step parent will be null </p><p>  and parent_interaction_id is null</p><p>),</p><p>-- Resolve analysis script_option hashs to script_option text</p><p>script_options as (select</p><p>  scripts.istep_id,</p><p>  scripts.campaign_id,</p><p>  hash_counts.hash_count,</p><p>  scripts.script_option,</p><p>  hash_counts.script_version_hash</p><p>from scripts</p><p>join hash_counts</p><p>  on hash_counts.script_version_hash = md5(scripts.script_option)</p><p>order by 1, 3 desc),</p><p>-- Response rate =</p><p>-- of everyone who got a certain initial, how many of them had ANY response</p><p>script_total_contacts as (</p><p>select m.script_version_hash,</p><p>       cc.id as campaign_contact_id,</p><p>       script_option</p><p>from message m</p><p>inner join campaign_contact cc on m.campaign_contact_id = cc.id</p><p>inner join script_options sc on sc.script_version_hash = m.script_version_hash),</p><p>script_response_contacts as (</p><p>select distinct campaign_contact_id from message</p><p>where is_from_contact = true</p><p>),</p><p>responded_bool as (</p><p>select</p><p>stc.campaign_contact_id,</p><p>stc.script_option,</p><p>case when src.campaign_contact_id is null then false</p><p>else true end as responded</p><p>from</p><p>script_total_contacts stc</p><p>left join script_response_contacts src on src.campaign_contact_id = stc.campaign_contact_id),</p><p>subtotals as (</p><p>select  script_option,responded, count(distinct campaign_contact_id) as subtotal_count</p><p>from responded_bool</p><p>group by script_option,responded),</p><p>totals as (</p><p>select  script_option,count(distinct campaign_contact_id) as total_count</p><p>from responded_bool</p><p>group by script_option)</p><p>select totals.script_option,</p><p>       responded,</p><p>       subtotal_count,</p><p>       total_count,</p><p>       subtotal_count::numeric*100 / total_count::numeric</p><p>from subtotals</p><p>left join totals on subtotals.script_option = totals.script_option</p><br /></pre><p
+			>
+				How to <strong>calculate ID rates</strong> by script option for Campaign
+				ID 75, <strong>for initial text only:</strong>
+			</p><pre><p>-- Your analysis on messages, grouped by the script_option_hash</p><p>with subtotal as (select value,</p><p>       m.script_version_hash,</p><p>       x.script_option,</p><p>       count(distinct qr.campaign_contact_id) as subtotal</p><p>from campaign c</p><p>left join campaign_contact cc on c.id = cc.campaign_id</p><p>left join question_response qr on cc.id = qr.campaign_contact_id</p><p>left join message m on cc.id = m.campaign_contact_id</p><p>left join</p><p>(with hash_counts as (</p><p>  select</p><p>    campaign_id,</p><p>    script_version_hash,</p><p>    count(*) as hash_count</p><p>  from message</p><p>  join campaign_contact</p><p>    on campaign_contact.id = message.campaign_contact_id</p><p>  where</p><p>    campaign_id in (75)</p><p>  group by 1, 2</p><p>),</p><p>-- Fetch script options as reference</p><p>scripts as (</p><p>  select</p><p>    interaction_step.id as istep_id,</p><p>    interaction_step.campaign_id,</p><p>    unnest(interaction_step.script_options) as script_option</p><p>  from interaction_step</p><p>  where campaign_id in (75)</p><p>-- EDITING HERE WILL CHANGE the &#39;interaction_step&#39; parent, and for initial texts, the </p><p>-- interaction step parent will be null </p><p>  and parent_interaction_id is null</p><p>)</p><p>-- Resolve analysis script_option hashs to script_option text</p><p>select</p><p>  scripts.istep_id,</p><p>  scripts.campaign_id,</p><p>  hash_counts.hash_count,</p><p>  scripts.script_option,</p><p>  hash_counts.script_version_hash</p><p>from scripts</p><p>join hash_counts</p><p>  on hash_counts.script_version_hash = md5(scripts.script_option)</p><p>order by 1, 3 desc) x on x.script_version_hash = m.script_version_hash</p><p>where c.id = 75</p><p>-- This line limits the question_value responses to those that include ---- numbers only - useful if you are calculating support % </p><p>and value ~ &#39;[0-9]&#39;</p><p>group by value, m.script_version_hash,x.script_option),</p><p>-- Calculate total sent of each script version</p><p>totals as (</p><p>select subtotal.script_version_hash,</p><p>       subtotal.script_option,</p><p>       sum(subtotal.subtotal) as total</p><p>from subtotal</p><p>group by script_version_hash, subtotal.script_option)</p><p>-- Final analysis</p><p>select st.*,</p><p>       t.total,</p><p>       case </p><p>	when t.total = 0 then t.total</p><p>     	else st.subtotal::numeric*100/t.total</p><p>       end as percent</p><p>from subtotal st</p><p>left join totals t on t.script_version_hash = st.script_version_hash</p><br /></pre><p
+			>
+				How to <strong
+					>analyze &quot;A/B&quot; test results using script versions</strong
+				> for Campaign ID 75:
+			</p><pre><p>-- Your analysis on messages, grouped by the script_option_hash</p><p>with hash_counts as (</p><p>  select</p><p>    campaign_id,</p><p>    script_version_hash,</p><p>    count(*) as hash_count</p><p>  from message</p><p>  join campaign_contact</p><p>    on campaign_contact.id = message.campaign_contact_id</p><p>  where</p><p>    campaign_id = 75</p><p>  group by 1, 2</p><p>),</p><p>-- Fetch script options as reference</p><p>scripts as (</p><p>  select</p><p>    interaction_step.id as istep_id,</p><p>    interaction_step.campaign_id,</p><p>    unnest(interaction_step.script_options) as script_option</p><p>  from interaction_step</p><p>  where campaign_id = 75</p><p>)</p><p>-- Resolve analysis script_option hashes to script_option text</p><p>select</p><p>  scripts.istep_id,</p><p>  scripts.campaign_id,</p><p>  hash_counts.hash_count,</p><p>  scripts.script_option,</p><p>  hash_counts.script_version_hash</p><p>from scripts</p><p>join hash_counts</p><p>  on hash_counts.script_version_hash = md5(scripts.script_option)</p><p>order by 1, 3 desc</p><p>;</p><br /></pre><p
+			>
+				How to analyze <strong>reply rates</strong> of &quot;A/B&quot; test
+				results for Campaign ID 75:
+			</p><pre><p>select </p><p>  ab_test.script_version_hash,</p><p>  responded,</p><p>  total,</p><p>  reply_rate,</p><p>  sample.text as sample_message</p><p>from (</p><p>    select</p><p>        script_version_hash,</p><p>        count(*) filter (where message_status &lt;&gt; &#39;messaged&#39; and message_status &lt;&gt; &#39;needsMessage&#39;) as responded,</p><p>        count(*) filter (where message_status &lt;&gt; &#39;needsMessage&#39;) as total,</p><p>        count(*) filter (where message_status &lt;&gt; &#39;messaged&#39; and message_status &lt;&gt; &#39;needsMessage&#39;) / </p><p>        (count(*) filter (where message_status &lt;&gt; &#39;needsMessage&#39;))::float * 100 as reply_rate</p><p>    from message</p><p>    join campaign_contact</p><p>      on campaign_contact.id = message.campaign_contact_id</p><p>    where campaign_id = 75</p><p>      and not exists (</p><p>        select 1 from message earlier_message</p><p>        where earlier_message.campaign_contact_id = campaign_contact.id</p><p>          and earlier_message.created_at &lt; message.created_at</p><p>      )</p><p>      and send_status = &#39;DELIVERED&#39;</p><p>    group by 1</p><p>) ab_test</p><p>join message sample on sample.id = (</p><p>  select id</p><p>  from message</p><p>  where message.script_version_hash = ab_test.script_version_hash</p><p>  limit 1</p><p>);</p><br /></pre><p
+			>
+				How to analyze <strong>opt out rates</strong> of &quot;A/B&quot;
+				test results for Campaign ID 75:
+			</p><pre><p>select </p><p>  ab_test.script_version_hash,</p><p>  opted_out,</p><p>  total,</p><p>  opt_out_rate,</p><p>  sample.text as sample_message</p><p>from (</p><p>    select</p><p>        script_version_hash,</p><p>        count(*) filter (where is_opted_out = true and message_status &lt;&gt; &#39;needsMessage&#39;) as opted_out,</p><p>        count(*) filter (where message_status &lt;&gt; &#39;needsMessage&#39;) as total,</p><p>        count(*) filter (where is_opted_out = true and message_status &lt;&gt; &#39;needsMessage&#39;) / </p><p>        (count(*) filter (where message_status &lt;&gt; &#39;needsMessage&#39;))::float * 100 as opt_out_rate</p><p>    from message</p><p>    join campaign_contact</p><p>      on campaign_contact.id = message.campaign_contact_id</p><p>    where campaign_id = 75</p><p>      and not exists (</p><p>        select 1 from message earlier_message</p><p>        where earlier_message.campaign_contact_id = campaign_contact.id</p><p>          and earlier_message.created_at &lt; message.created_at</p><p>      )</p><p>      and send_status = &#39;DELIVERED&#39;</p><p>    group by 1</p><p>) ab_test</p><p>join message sample on sample.id = (</p><p>  select id</p><p>  from message</p><p>  where message.script_version_hash = ab_test.script_version_hash</p><p>  limit 1</p><p>);</p><br /></pre>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-admins/elections-organizer-guide.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/elections-organizer-guide.astro
@@ -1,0 +1,304 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">Elections Organizer Guide</h2>
+
+			<h2>TEXTING BASICS&nbsp;</h2><p>
+				Welcome to the Texting Program Organizer Guide! This is intended
+				to be near-comprehensive resource for getting your campaign's
+				texting program off the ground. It covers the digital tools and
+				infrastructure you'll need to set up, the volunteer materials
+				you'll need to prepare, how to build up your team, and how to
+				manage Spoke.
+			</p><p>
+				Peer-to-peer texting is an immensely powerful tool for Left
+				electoral campaigns to unleash the potential of trained
+				volunteers to efficiently reach large numbers of voters with the
+				campaign’s core message, while empowering those volunteers to
+				have real and meaningful conversations with both voters and
+				supporters.&nbsp;
+			</p><p>
+				Peer-to-peer texting programs can be broken down into two major
+				functions:
+				<strong> voter contact</strong>and <strong
+					>supporter mobilization</strong
+				>. Voter contact means texting lists of voters in order to
+				identify their level of support (voter ID), persuade them to
+				support your candidate, and get confirmed supporters to turn out
+				to vote (GOTV). Supporter mobilization means texting your
+				campaign’s list of supporters (volunteers, donors, website
+				signups) in order to recruit them to volunteer, attend an event,
+				donate to the campaign, etc. This guide will have a focus on
+				voter contact, though the core principles and systems described
+				here are generally applicable to both types of texting.&nbsp;
+			</p><h2>DIGITAL TOOLS</h2><h3>Spoke</h3><p>
+				This guide will describe how to set up a peer-to-peer texting
+				program using Spoke Rewired, which we believe offers the most
+				powerful set of features at the lowest
+				price&nbsp;($0.01/segment) of any tool on the market. Spoke
+				Rewired is a highly scaleable, dynamic and easy-to-use tool for
+				admins and texters.
+			</p><h3>Slack</h3><p>
+				You will need a highly reliable online communications platform
+				in order to coordinate your peer-to-peer texting program. Slack
+				is a free and easy-to-use online messaging program that allows
+				your team to have multiple live conversations, neatly organized
+				into different channels and threads. While some newer
+				open-source tools&nbsp;(e.g., Discord)&nbsp;can now provide
+				similar functionality, Slack is still generally considered to be
+				the most powerful and reliable and will therefore be recommended
+				in this guide. Do not try to coordinate your texting program via
+				email, WhatsApp, or group text. Slack’s ability to keep your
+				conversations clear and organized makes it well-worth the
+				(relatively minor) extra training and support needed to get
+				volunteers onboarded and comfortable using the platform.&nbsp;
+			</p><h3>Google Drive</h3><p>
+				Admin resources and volunteer materials can be easily created,
+				stored, and organized using Google Drive, Docs, Sheets, Forms,
+				and Slides. This guide will provide templates of said resources
+				and materials that you can copy, edit, and adapt for your
+				campaign’s texting program.&nbsp;
+			</p><h2>GETTING STARTED: ADMIN INFRASTRUCTURE&nbsp;</h2><p>
+				A peer-to-peer texting program is a kind of distributed
+				organizing system, which means it requires a significant
+				up-front investment of time and attention to prepare the digital
+				infrastructure that admins and volunteers will rely upon to
+				accomplish their work in an entirely online and remote setting.
+				This section will cover the admin infrastructure you’ll need in
+				place before you launch your texting program.
+			</p><h3>Sign up for Spoke Rewired</h3><p>
+				If you don't yet have a Spoke Rewired account, you can sign up
+				for one
+				<a href="https://politicsrewired.com/signup/">here</a>. You
+				should hear back and be granted access to your new account in a
+				matter of days.
+			</p><h3>Acquire Voter Data</h3><p>
+				You will need to purchase voter data from your state or county
+				elections office(s), VAN, or if you’re in California, PDI. You
+				only need to purchase voters with valid cell numbers, since
+				peer-to-peer texting only reaches cell phones, not landlines. If
+				you’re in California, PDI generally offers the most accurate and
+				up-to-date data available. You can quickly and easily filter
+				various PDI lists
+				<a href="https://www.politicaldata.com/online-counts-reports/"
+					>here</a
+				>, searching your district and then applying the “HAS MOBILE
+				PHONE” criteria to your search. You can then further narrow your
+				search by various demographic information, depending on your
+				budget for data and texting.
+			</p><h3>Develop Voter ID Script</h3><p>
+				A key component of your voter contact texting will be voter ID
+				work: texting campaigns designed to identify voters’ level of
+				support for your candidate on a 1-5 scale. You will need to
+				develop a script ahead of time that includes an initial message
+				that will be sent to your entire voter universe asking if they
+				will support your candidate, as well as messages designed to
+				respond to voters who reply indicating varying levels of
+				support. It’s important that you take time to carefully craft a
+				clear and concise initial message that introduces your
+				candidate, summarizes their most central message, and asks for
+				support. You should send your draft script to campaign
+				leadership for feedback and approval well in advance of
+				launching your texting program. You can request a sample Voter
+				ID script outline at support@spokerewired.com
+			</p><h3>Create Campaign Tracker</h3><p>
+				If you’re building and managing texting campaigns in your own
+				Spoke account, it’s best to have a campaign tracker spreadsheet
+				that will help your admin team track and coordinate its work.
+				Your campaign tracker will be where you can quickly and easily
+				see all your texting campaigns, their number and current status,
+				who built them, and any notes left by the builder. It will also
+				provide a checklist for proofing campaigns. You can view a
+				request a&nbsp;campaign tracker template&nbsp;at
+				support@spokerewired.com
+			</p><h3>Sign up for Rebrandly</h3><p>
+				You will frequently need to send links while texting voters and
+				supporters. You can generate links that are short, branded, and
+				less likely to be blocked by cell carriers by creating a
+				Rebrandly account and purchasing a custom domain. Rebrandly is
+				free to use and domains typically cost between $2-$35. Once you
+				purchase a domain, you can create unlimited custom links
+				associated with that doman. You can create an account with
+				Rebrandly
+				<a href="https://app.rebrandly.com/sign-up">here</a>.&nbsp;
+			</p><h2>GETTING STARTED: VOLUNTEER MATERIALS</h2><p>
+				Volunteers are the beating heart of any distributed organizing
+				program and peer-to-peer texting perfectly illustrates that
+				point. Enabling and empowering volunteers with clear and
+				thorough resources is key to running a successful texting
+				program. Three online resources are absolutely critical:
+				training slides, your Team FAQ, and your Slack workspace.
+			</p><h3>Training Slides</h3><p>
+				Your training slides will be what you use to train new volunteer
+				texters before they are invited into Slack or Spoke. Training
+				slides should provide a reasonably comprehensive overview of
+				what a texting volunteer will need to text using Spoke and
+				coordinate with your team on Slack. Ideally, all volunteer
+				texters should attend a live online training that reviews the
+				training slides, though a pre-recorded video covering the slides
+				can also be used. You can&nbsp;request a template for your
+				training slides&nbsp;at support@spokerewired.com
+			</p><h3>Team FAQ</h3><p>
+				No matter how comprehensive your training slides are, your
+				volunteer texters are bound to have plenty of questions. Your
+				Team FAQ will be the first place texting volunteers look in
+				order to find answers to their common questions. This will allow
+				your admin team (and/or moderators) to focus their attention on
+				answering more complex questions in Slack that can’t be easily
+				addressed in the FAQ. The FAQ should include common questions
+				from both texters and voters. It should cover biographical and
+				political summaries of the candidate, as well as succinct
+				descriptions of their position on the most important and
+				controversial issues of the race.&nbsp;You can request a
+				template for your Team FAQ at support@spokerewired.com
+			</p><h3>Slack Workspace</h3><p>
+				If your campaign does not already use Slack, you’ll want to set
+				up a new workspace for your texting team. You can read how to
+				create a new workspace
+				<a
+					href="https://slack.com/help/articles/206845317-Create-a-Slack-workspace"
+					>here</a
+				>. Once in your new workspace, create a new #texting channel and
+				set the channel description so that volunteers know that all
+				questions and conversations about texting should happen here.
+				Then, set the channel description in #general to make it clear
+				that that’s where all non-texting-related announcements and
+				discussion will take place. Once channel descriptions are set,
+				edit the channel topics to include important links that
+				volunteers will regularly be referencing while texting. For
+				example, you can set the topic for #texting include links to the
+				FAQ, training slides, and the candidate’s platform page. The
+				most important thing to post to the #general channel is
+				the&nbsp; link texting volunteers will need to join Spoke. You
+				may also want to create a private #admins channel for those who
+				are managing your texting program. Links posted as channel
+				topics will need to be shortened, ideally using branded links
+				created in rebrandly. (If your campaign already has a Slack
+				workspace, then all you’ll need to do is create a new #texting
+				channel that includes links volunteer materials and to join
+				Spoke in the channel topic. You’ll also likely want to create a
+				private #texting-admins channel.)
+			</p><p>
+				Just as important as the structure of your Slack workspace is
+				the culture you create in it with your volunteer texting team.
+				Make sure to set a
+				<a
+					href="https://slack.com/help/articles/204379773-Upload-a-Slack-icon"
+					>workplace icon</a
+				> so that your workspace looks official and people are excited to
+				join. You’ll also want to set a <a
+					href="https://slack.com/help/articles/115005506003-Upload-a-profile-photo"
+					>profile photo</a
+				> and encourage all other admins and texters to do the same, so that
+				people can get to know one another. (Profile photos don’t necessarily
+				have to be a picture of the person; they can be of a favorite place,
+				pet, etc.) Finally, it’s worth taking a little extra time to add
+				some fun <a
+					href="https://slack.com/slack-tips/upload-custom-slack-emoji-to-express-your-unique-office-culture"
+					>custom emojis</a
+				> to your workspace. You can browse a free library of custom emojis
+				<a href="https://slackmojis.com/">here</a>.
+			</p><h2>BUILDING YOUR TEXTING TEAM</h2><h3>
+				Recruiting Volunteers
+			</h3><p>
+				Once you’ve prepared your admin infrastructure and volunteer
+				materials, you’ll need to recruit your team of volunteer
+				texters. Reaching out to local chapter members and/or people who
+				have signed up to volunteer are good places to start. Since most
+				down-ballot races have relatively modest and manageable voter
+				lists, you should be able to handle your voter universe with
+				between 5-15 well-trained and committed volunteers, depending on
+				the size of your voter universe and the technical literacy of
+				your volunteers. In general, it’s better to have fewer texting
+				volunteers that are competent and reliable, rather than large
+				numbers of volunteers who demand constant support and are
+				flakey. When reaching out to volunteers, briefly describe the
+				texting program and why it’s important, then invite them to a
+				live online training to get started!&nbsp;
+			</p><h3>Onboarding Volunteers</h3><p>
+				The way in which you onboard new texting volunteers is an
+				important mechanism for ensuring that everyone on your team has
+				access to the same resources and is prepared to begin texting
+				with your campaign. The first step is to invite new texter
+				recruits to a live online training (Zoom is a good option). Make
+				sure they register to attend the training, so you collect their
+				contact information. At the end of the training, you should
+				invite all those in attendance to join your Slack workspace by
+				sharing the custom invite link in the chat. Allocate 5-10
+				minutes at the end of the training to actively support and
+				troubleshoot people creating a Slack account and getting into
+				the workspace. You can then post the Spoke login information in
+				Slack so that texting volunteers are able to create a Spoke
+				account, which they will need to start texting. Going through
+				this ordered process will guarantee that all your texters are
+				trained, in Slack, and in Spoke. Do not invite new recruits
+				directly into Spoke without first making sure they are trained
+				and in Slack. This will only cause you headaches down the
+				line.&nbsp;
+			</p><p>
+				Note: If you want to add an extra layer of training and
+				accountability to your onboarding process, you can also require
+				new trainees to pass a simple online quiz that covers the
+				training material. Those that pass the quiz should be
+				automatically invited to your Slack workspace.&nbsp;
+			</p><h3>Schedule Texting Sessions</h3><p>
+				Texting is usually a periodic activity, with interchanging
+				periods of high activity and low activity, centered around Voter
+				ID and GOTV campaigns. To provide a reliable schedule for your
+				volunteers and to ensure that they’ll have the live support of
+				admins or moderators in Slack while texting, you’ll want to
+				schedule specific texting sessions. A good rule of thumb is to
+				schedule 2-3 sessions, each several hours, over 2-3 consecutive
+				days when you think most of your volunteers will be available
+				during the week following your first training. For example, you
+				may schedule texting sessions from Mon-Wed from 6:00-9:00 PM
+				after holding a weekend training. After your first complete
+				session, you’ll get a better sense of how long it’s taking your
+				team of volunteers to get through texts and can schedule
+				additions sessions as needed.
+			</p><h2>MANAGING SPOKE</h2><h3>Building Campaigns</h3><p>
+				There are a number of ways to organize and customize how you
+				build and manage campaigns in Spoke, but it’s crucial that you
+				take a systematic approach in order to avoid errors and ensure
+				consistency between campaigns created by different admins. For a
+				detailed step-by-step guide to campaign building, go
+				<a
+					href="https://docs.spokerewired.com/article/34-build-a-campaign"
+					target="_blank">here</a
+				>.&nbsp;
+			</p><h3>Scripting Initial Messages</h3><p>
+				A campaign’s initial message will be sent to its entire voter or
+				supporter universe and will play a large role in determining
+				both how many people respond to start a conversation and the
+				nature of those conversations. Initial messages should be clear,
+				concise, and compelling. They can usually be broken down into
+				three parts: an introduction, an argument, and an ask. The
+				introduction greets the textee and introduces the texter. The
+				argument makes a case for why the textee should yes to the ask.
+				The ask makes a direct request of the textee, including any
+				logistical details (e.g., date/time) they may need to give an
+				informed answer. For more details about how to write effective
+				scripts and for example scripts, please
+				<a
+					href="https://docs.spokerewired.com/article/120-writing-scripts"
+					target="_blank">read this article</a
+				>.
+			</p><p>
+				<em
+					>To learn more about managing campaigns and administering
+					Spoke, please browse our <a
+						href="https://docs.spokerewired.com/"
+						target="_blank">Knowledge Base</a
+					>.</em
+				>
+			</p>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-admins/export-data-from-a-campaign.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/export-data-from-a-campaign.astro
@@ -1,0 +1,67 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">Export Data From A Campaign</h2>
+
+			<p>
+				Every campaign has two sets of data associated with it: campaign
+				data and message data.
+			</p><ol>
+				<li>
+					Export
+					<strong style="background-color: initial;"
+						>campaign data</strong
+					> to access&nbsp;your updated contact list, complete with their
+					conversation statuses and survey responses. Every row will be
+					a contact.
+				</li>
+				<li>
+					Export <strong style="background-color: initial;"
+						>message data</strong
+					> to get a breakdown of every message that was sent or received,
+					including whether or not it was successfully delivered. Every
+					row will be a message.
+				</li>
+			</ol><h5><em>To export data from a campaign:</em></h5><ol>
+				<li>
+					Open a campaign from the <strong>Campaigns</strong> page<br
+					/>
+					<br />
+
+					<blockquote>
+						Note: If the campaign has not started, the campaign
+						settings page opens. To open the campaign page, remove
+						"edit" from the URL.
+					</blockquote>
+				</li>
+				<li>
+					Click <strong>Export Data</strong>. This starts the export
+					process.
+				</li>
+				<li>
+					Open your email, and wait for a message from Spoke Rewired.
+					Exporting campaign data can take a long time, depending on
+					the amount of data. Check your spam folder if you haven't
+					received an email in a reasonable amount of time.
+				</li>
+				<li>
+					Click the first link to download the <strong
+						>campaign data</strong
+					>.
+				</li>
+				<li>
+					Click the second link to download the <strong
+						>message data</strong
+					>.
+				</li>
+			</ol>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-admins/export-for-upload-to-van.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/export-for-upload-to-van.astro
@@ -1,0 +1,54 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">Export For Upload To Van</h2>
+
+			<p>
+				The "Export for VAN" feature allows you to export survey
+				responses collected during a Spoke campaign in a format that may
+				be easier for upload back into VAN.
+			</p><p>
+				From the campaign page, <strong>select Export for VAN:</strong>
+			</p><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/5f298c022c7d3a31c76a716b/file-SvaEnyLKUE.png"
+				/>
+			</p><p>This will then open the Export for VAN dialog.</p><p>
+				Select which field the VAN ID lives in. <strong
+					>If you are using our VAN integration, you should leave the
+					default of "external_id".</strong
+				> If you uploaded contacts via a CSV, you'll need to select the heading
+				of the column in the CSV that contained your VAN IDs. For example,
+				this could be <em>van_id:</em>
+			</p><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/5f298cb72c7d3a31c76a7184/file-2xMsjFo6xI.png"
+				/>
+			</p><p>
+				In most cases, you'll only want to include survey responses for
+				contacts to whom you actually sent a message. However, you have
+				a choice to include all contacts, regardless of whether or not
+				they have been messaged. To do so, toggle on <em
+					>Include unmessaged contacts.</em
+				>
+			</p><p>
+				<strong
+					>After clicking the <em>Export</em>button, you'll receive an
+					email
+				</strong>containing a link to download the export.&nbsp;<br />
+				<br />
+				For assistance completing the bulk upload back into VAN, <a
+					href="https://supportcenter.ngpvan.com/contact-us"
+					>contact NGP VAN support!</a
+				>
+			</p>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-admins/how-to-use-documentation.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/how-to-use-documentation.astro
@@ -1,0 +1,63 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">How To Use Documentation</h2>
+
+			<p>
+				The documentation on this website is intended for both
+				administrators and texters using Spoke Rewired.&nbsp;You can
+				browse the collections of articles below to learn more about
+				using the platform based on your role.&nbsp;You can also look
+				for articles on specific topics using the search bar on the
+				<a href="https://docs.spokerewired.com/">homepage</a>.
+			</p><h4>Administrators</h4><p>
+				If you are an administrator, we recommend looking through the
+				following categories:
+			</p><ul>
+				<li>
+					<a
+						href="https://docs.spokerewired.com/category/39-managing-campaigns"
+						>Building &amp; Managing Campaigns</a
+					> -- Guides for administrators to create and manage texting campaigns
+				</li>
+				<li>
+					<a
+						href="https://docs.spokerewired.com/category/42-administering-spoke"
+						>Administering Spoke</a
+					> -- Guides for administrators to set up user accounts, assign
+					texts, create teams, and more
+				</li>
+				<li>
+					<a href="https://docs.spokerewired.com/category/24-concepts"
+						>Concepts</a
+					> -- Articles describing the different components you'll find
+					in Spoke
+				</li>
+			</ul><h4>Texters</h4>
+			<div>
+				If you are a texter, we recommend looking through the following
+				categories:
+			</div><ul>
+				<li>
+					<a
+						href="https://docs.spokerewired.com/category/40-texting-contacts"
+						>How to Text</a
+					> -- Guides for texters using Spoke&nbsp;
+				</li>
+				<li>
+					<a href="https://docs.spokerewired.com/category/24-concepts"
+						>Concepts</a
+					> -- Articles describing the different components you'll find
+					in Spoke
+				</li>
+			</ul>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-admins/include-an-image-in-a-message.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/include-an-image-in-a-message.astro
@@ -31,10 +31,12 @@ import "animate.css";
 				</li>
 				<li>Click <strong>Send</strong>.</li>
 			</ol><h3>Example:&nbsp;</h3><p>
-				Hey <span style="background-color: initial;">{firstName}</span>,
-				this is {texterFirstName} with ORGANIZATION. URGENT FACT. That is
-				why we are organizing to X. Will you stand in solidarity and sign
-				our pledge to Y? [https://i.imgur.com/d2DkMaZ.jpeg]
+				Hey <span style="background-color: initial;"
+					>&lcub;firstName&rcub;</span
+				>, this is &lcub;texterFirstName&rcub; with ORGANIZATION. URGENT
+				FACT. That is why we are organizing to X. Will you stand in
+				solidarity and sign our pledge to Y?
+				[https://i.imgur.com/d2DkMaZ.jpeg]
 			</p><h2>Size limitations</h2><p>
 				Cellular carriers have different limitations on MMS attachments.
 				We recommend keeping attachment size below <strong

--- a/src/pages/docs/spoke/for-spoke-admins/include-an-image-in-a-message.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/include-an-image-in-a-message.astro
@@ -1,0 +1,97 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">Include An Image In A Message</h2>
+
+			<p>
+				You can include images with your messages to send event posters
+				or other media to your contacts.&nbsp;
+			</p><blockquote>
+				Note: Multimedia messages cost more to send than text-only
+				messages. Ask your organization for guidelines and permission.
+				<br />
+			</blockquote><p>To include images with your messages:</p><ol>
+				<li>
+					From a conversation, paste a URL between two square
+					brackets, [ ]. For example: <code
+						>[https://image-url.com/image-is-here]</code
+					>.
+				</li>
+				<li>
+					Write a message to be sent with the image. Any text before
+					and after the bracketed URL is combined into a single
+					message with the bracketed URL removed.
+				</li>
+				<li>Click <strong>Send</strong>.</li>
+			</ol><h3>Example:&nbsp;</h3><p>
+				Hey <span style="background-color: initial;">{firstName}</span>,
+				this is {texterFirstName} with ORGANIZATION. URGENT FACT. That is
+				why we are organizing to X. Will you stand in solidarity and sign
+				our pledge to Y? [https://i.imgur.com/d2DkMaZ.jpeg]
+			</p><h2>Size limitations</h2><p>
+				Cellular carriers have different limitations on MMS attachments.
+				We recommend keeping attachment size below <strong
+					>600 KB</strong
+				> for best results.
+			</p><p>Size limitations for the top 4 US carriers are:</p>
+			<table>
+				<tbody>
+					<tr>
+						<td>
+							<strong>Carrier</strong>
+						</td>
+						<td>
+							<strong>MMS attachment size</strong>
+						</td>
+					</tr>
+					<tr>
+						<td> AT&amp;T</td>
+						<td> 1.4 MB</td>
+					</tr>
+					<tr>
+						<td> Sprint</td>
+						<td> 1.4 MB</td>
+					</tr>
+					<tr>
+						<td> T-mobile</td>
+						<td> 0.675 MB</td>
+					</tr>
+					<tr>
+						<td> Verizon</td>
+						<td> 0.675 MB</td>
+					</tr>
+				</tbody>
+			</table><h2>Media type limitations</h2><p>
+				MMS attachments may be of the following types:
+			</p><ul>
+				<li>image/jpeg</li><li>image/png</li><li>image/gif</li><li>
+					video/3gpp
+				</li><li>video/mp4</li>
+			</ul><h2>Send an image with links</h2><p>
+				The SMS/MMS protocol, regardless of provider, does not support
+				hyperlinked images. If you want to provide a link with an
+				accompanying image, you can add <a
+					href="https://css-tricks.com/essential-meta-tags-social-media/"
+					>meta tags for social media</a
+				> to the linked website itself, and then send the link. These tags
+				let messaging applications show a preview of the linked content.
+				For example, this is how YouTube link previews are displayed.
+			</p>
+			<div>
+				If you don't have control of the linked website, you can create
+				an intermediate page that redirects to the destination page
+				<a href="https://www.lifewire.com/meta-refresh-tag-3469046"
+					>using a refresh tag</a
+				>. Then, you can add meta tags to the intermediate page.
+				<br />
+			</div>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-admins/index.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/index.astro
@@ -1,0 +1,16 @@
+---
+import SpokeDocsList from "../../../../components/DocsCollection/SpokeDocsList.astro";
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+    <main
+        class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+    >
+        <h2 class="text-center">For Spoke Admins</h2>
+        <div class="flex items-center flex-col">
+            <SpokeDocsList collectionType="for-spoke-admins" />
+        </div>
+    </main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-admins/interaction-scripts.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/interaction-scripts.astro
@@ -1,0 +1,43 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">Interaction Scripts</h2>
+
+			<p>
+				Interaction scripts define a campaign's conversation flow and
+				survey questions. They are used by texters to send prepared
+				scripts to contacts and to record responses to survey. Each
+				campaign has an interaction script that can be written and
+				edited on the campaign settings page. Only administrators can
+				edit interactions scripts.
+			</p><h5><em>An interaction script has three parts:</em></h5><ol>
+				<li>
+					An initial message that a texter sends out to all contacts
+					to start a conversation
+				</li>
+				<li>
+					A set of survey questions and answers that texters use to
+					record information about the conversation
+				</li>
+				<li>
+					A set of follow-up messages that correspond with those
+					survey answers and that can vary depending on how a contact
+					replies
+				</li>
+			</ol><p>
+				If a conversation departs from the interaction script, you can
+				provide <a
+					href="https://docs.spokerewired.com/article/47-canned-responses"
+					target="_blank">canned responses</a
+				> that texters use to handle the situation on a case-by-case basis.
+			</p>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-admins/invite-texters-to-spoke.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/invite-texters-to-spoke.astro
@@ -1,0 +1,56 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">Invite Texters To Spoke</h2>
+
+			<p>
+				You can invite new texters to join your organization on Spoke by
+				sending them an invitation link. When someone clicks on the
+				link, they'll be prompted to create a new texter account. After
+				a texter creates their account, you can <a
+					href="https://docs.spokerewired.com/article/35-change-user-roles"
+					target="_blank">change their user role</a
+				> as needed.
+			</p><h5>
+				<em>To invite texters to join your organization:</em>
+			</h5><ol>
+				<li>
+					From the administration <a
+						href="https://docs.spokerewired.com/article/52-dashboards"
+						target="_blank">dashboard</a
+					>, navigate to the <strong>People</strong> page.
+				</li>
+				<li>
+					Click the green&nbsp;<strong>plus (+)</strong><strong
+						>&nbsp;</strong
+					>button in the bottom right-hand corner.
+				</li>
+				<li>Copy the URL.</li>
+				<li>
+					Share the URL with the texter(s) you want to invite. When
+					someone clicks on the link, they will be able to create an
+					account.
+				</li>
+			</ol><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/601d9cb0ac2f834ec5385f0f/file-aT0Ya55Vvl.png"
+				/>
+			</p><blockquote>
+				Note: This URL is unique to your Spoke
+				<a
+					href="https://docs.spokerewired.com/article/79-organizations"
+					target="_blank">organization</a
+				>. It will now allow texters to join other organizations and
+				texters already from another organization will not be able to
+				join yours unless they're given the unique link.
+			</blockquote>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-admins/manage-assignment-control.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/manage-assignment-control.astro
@@ -1,0 +1,99 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">Manage Assignment Control</h2>
+
+			<p>
+				The <strong>Assignment Control</strong> page on the administration
+				dashboard allows you to manage the <a
+					href="https://docs.spokerewired.com/article/110-request-form"
+					target="_blank">request form</a
+				> that distributes texting <a
+					href="https://docs.spokerewired.com/article/33-text-assignment"
+					target="_blank">assignments</a
+				> to you texters. Assignment controls can be applied to all of your
+				texters via the "General" designation, or to specific teams of texters.
+			</p><p>There are three primary assignment controls:</p><p>
+				<strong>1. Enable Assignment:</strong>Toggling the "Enable
+				assignment?" switch will make assignments available to texters
+				via the request form from any active campaigns that have <a
+					href="https://docs.spokerewired.com/article/110-request-form"
+					target="_blank">autoassign</a
+				> enabled.&nbsp;
+			</p><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/5fca9443eb7cc612aa3550b2/file-WvTtjrLqjX.png"
+				/><strong style="background-color: initial;"
+					>2. Assignment Type:
+				</strong>This allows you to choose whether you want to release
+				unsent initial messages or unhandled replies to the request
+				form.&nbsp;
+			</p><ul>
+				<li>
+					<em style="background-color: initial;"
+						>Unsent Initial Messages:&nbsp;</em
+					>conversations where the contact has not yet received an
+					initial message.
+				</li>
+				<li>
+					<em style="background-color: initial;"
+						>Unhandled Replies:</em
+					>&nbsp;Conversations where the the contact has responded to
+					a message and is awaiting a reply.&nbsp;
+				</li>
+			</ul><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/5fca9456eb7cc612aa3550b3/file-aERtmsOutQ.png"
+				/><strong style="background-color: initial;"
+					>3. Max to Request at Once:
+				</strong>This allows you to set the maximum number of
+				conversations that a texter can request per assignment.
+			</p><ul>
+				<li>
+					<em style="background-color: initial;"
+						>Unsent Initial Messages:
+					</em>We typically recommend setting your max limit for
+					initial messages between <strong
+						style="background-color: initial;">100-1000</strong
+					>. It's safer to start smaller so new texters are not
+					overwhelmed by replies, though most will find assignments of
+					500+ messages to be manageable.
+				</li>
+				<li>
+					<em>Unhandled Replies:&nbsp;</em>We typically recommend
+					setting your max limit for unhandled replies&nbsp;between <strong
+						style="background-color: initial;">10-30</strong
+					>. Setting small maximum limits for replies will encourage
+					texters to take their time, apply accurate survey responses,
+					and customize scripts, while large max limits may encourage
+					more rushed and robotic responses.
+				</li>
+			</ul><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/5fca9548eb7cc612aa3550bd/file-mozigPavCz.png"
+				/>
+			</p><p>
+				The final setting you'll see in Assignment Control is for <strong
+					style="background-color: initial;"
+					>custom escalation tags</strong
+				>. Adding custom escalation tags to a specific team enables
+				texters who are part of that team to apply those custom tags
+				while texting. For more information, please read about <a
+					href="https://docs.spokerewired.com/article/67-conversation-tags"
+					target="_blank">conversation tags</a
+				>
+			</p><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/5fca93b9de1bfa158fb558c1/file-Zz2d9kUxb3.png"
+				/>
+			</p>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-admins/message-review.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/message-review.astro
@@ -1,0 +1,220 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">Message Review</h2>
+
+			<p>
+				The Message Review page of your administration <a
+					href="https://docs.spokerewired.com/article/52-dashboards"
+					target="_blank">dashboard</a
+				> allows you to filter through your organization's conversations,
+				as well as reassign or unassign conversations that you've selected.
+			</p><h2>Message Filter</h2><p>
+				Within the Message Review page, click open the <strong
+					>Message Filter</strong
+				> window. You can then use the available filtering criteria to find
+				and review specific conversations. Once you select your filtering
+				criteria, a list of conversations will automatically generate based
+				on that selection. As you update your criteria, the list will also
+				update in real time.
+			</p><blockquote>
+				Note: Try and start with criteria selections that will narrow
+				the breadth of your search so that the system doesn't get
+				stalled trying to generate an unwieldy list. For example,
+				filtering by campaign or texter is often a good place to start.
+			</blockquote><h4>Filtering Criteria - Toggles</h4><p>
+				There are numerous toggles you can switch ON or OFF to help
+				filter conversations.
+			</p><ul>
+				<li>
+					<strong>Active Campaigns:</strong> select whether or not you
+					want to display conversations from active campaigns.
+				</li>
+				<li>
+					<strong>Archived Campaigns:</strong>&nbsp;select whether or
+					not you want to display conversations from
+					archived&nbsp;campaigns.
+
+					<ul>
+						<li>
+							<em
+								>The default position is OFF, so that you'll
+								only be looking at conversations from active
+								campaigns. You may need to turn this ON if you
+								want to review conversations from older
+								campaigns.</em
+							>
+						</li>
+					</ul>
+				</li>
+				<li>
+					<strong>Not Opted Out:</strong>&nbsp;select whether or not
+					you want to display conversations from contacts who have not
+					opted out.
+				</li>
+				<li>
+					<strong>Opted Out:</strong>&nbsp;select whether or not you
+					want to display conversations from contacts who have opted
+					out.&nbsp;
+
+					<ul>
+						<li>
+							<em
+								>The default position is OFF, so that you'll
+								only be looking at conversations with contacts
+								who are still opted in. This can be helpful to
+								toggle ON if you're looking to make sure your
+								texters are not incorrectly opting people out.</em
+							>
+						</li>
+					</ul>
+				</li>
+				<li>
+					<strong>Include Escalated:</strong>&nbsp;select whether or
+					not you want to display escalated conversations.
+
+					<ul>
+						<li>
+							<em
+								>The default position is ON. Make sure to turn
+								it OFF if you're going to be bulk reassigning or
+								unassigning conversations, so that you don't
+								mistakenly remove escalated conversations from
+								the escalated convos workflow.</em
+							>
+						</li>
+					</ul>
+				</li>
+			</ul><h4>Filtering Criteria - Fields</h4><p>
+				There are also a number of drop-down and search fields you can
+				use to filter conversations.
+			</p><ul>
+				<li>
+					<strong>Contact Message Status:</strong>decide which
+					conversations to review based on the status of those
+					conversations. One or multiple of the following statuses may
+					be selected:
+
+					<ul>
+						<li><em>All</em>– Conversations of all statuses.</li>
+						<li>
+							<em>Needs Texter Response</em> – Conversations where
+							the contact has replied but not yet received a response
+							from a texter.
+						</li>
+						<li>
+							<em>Needs First Message</em> – Conversations where the
+							contact has not yet received the initial message.
+						</li>
+						<li>
+							<em>Active Conversations</em> – Conversations where the
+							the contact has replied and the texter has responded.
+						</li>
+						<li>
+							<em>First Message Sent</em>– Conversations where the
+							initial message has been sent but the contact has
+							not replied.
+						</li>
+						<li>
+							<em>Closed</em>– Conversations where the texter has
+							selected <a
+								href="https://docs.spokerewired.com/article/80-skip-a-reply"
+								target="_blank">Close</a
+							>, effectively closing the conversation.
+						</li>
+					</ul>
+				</li>
+				<li>
+					<strong>Campaign:</strong>filter conversations by campaign
+					name or ID number. This is often the first step when
+					searching for specific conversations.
+				</li>
+				<li>
+					<strong>Texter:</strong> filter conversations by texter name.
+					This if usually the first step when searching for conversations
+					in a specific texter's workflow.
+				</li>
+				<li>
+					<strong>Filter by Contact Name:</strong>filter conversations
+					based on the name of the contact being texted.
+				</li>
+				<li>
+					<strong>Filter by Contact Tags:</strong> filter conversations
+					based on tags that have been applied to those conversations.
+				</li>
+			</ul><h2>Message Actions</h2><p>
+				Once you've generated a filtered list of conversations, you're
+				then able to perform actions on one, several, or all of those
+				filtered conversations. There are two available actions:
+			</p><h4>Reassign</h4><p>
+				Reassigning conversations removes them from their current
+				texter's workflow and places them in a new texter's
+				workflow.&nbsp;
+			</p><h5><em>To reassign conversations:</em></h5><ol>
+				<li>
+					Use <strong>Message Filter</strong>to generate a filtered
+					list.&nbsp;
+				</li>
+				<li>
+					Click <strong>Message Actions</strong>,&nbsp;then select <strong
+						>Reassign</strong
+					>.
+				</li>
+				<li>
+					Click the <strong>Select at least one texter</strong>field
+					and pick one or more texters to receive the reassigned
+					texts. If you select multiple texters, the reassigned
+					messages will be evenly split between them.
+				</li>
+				<li>
+					Select one or more conversations to reassign using the
+					checkboxes, then click<strong
+						>&nbsp;Reassign Selected</strong
+					>. Or, if you want to reassign the entire filtered list,
+					click&nbsp;<strong>Reassign All x Matching</strong
+					>,&nbsp;then select <strong>Reassign</strong>.
+				</li>
+			</ol><h4>Unassign</h4><p>
+				Unassigning conversations removes them from their current
+				texter's workflow and places them in the pool of texts available
+				for assignment via the <a
+					href="https://docs.spokerewired.com/article/110-request-form"
+					target="_blank">request form</a
+				>.
+			</p><h5><em>To unassign conversations:</em></h5><ol>
+				<li>
+					Use&nbsp;<strong>Message Filter</strong>&nbsp;to generate a
+					filtered list.&nbsp;
+				</li>
+				<li>
+					Click&nbsp;<strong>Message Actions</strong>,&nbsp;then
+					select <strong>Unassign</strong>.
+				</li>
+				<li>
+					Select one or more conversations to unassign using the
+					checkboxes, then click <strong>Unaassign Selected</strong>.
+					Or, if you want to unassign the entire filtered list, click <strong
+						>Unassign All x Matching</strong
+					>,&nbsp;then select <strong>Unassign</strong>.&nbsp;
+				</li>
+			</ol><blockquote>
+				Note: Once you generate a filtered list, you can review
+				individual conversations by clicking the box below the
+				<strong>View Conversation</strong>&nbsp;column. From that view,
+				you can see all messages that have been exchanged and all survey
+				answers that have been selected for that conversation. You are
+				also able to send additional messages, edit survey answers,
+				manage tags, and opt out or un-opt out contacts. You can toggle
+				to other conversations in your list using the navigation left
+				(&lt;) and right (&gt;) arrows.
+			</blockquote>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-admins/organizations.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/organizations.astro
@@ -1,0 +1,54 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">Organizations</h2>
+
+			<p>
+				An
+				<strong>organizatio</strong><strong>n</strong> is a distinct sending
+				identity within your Spoke instance.&nbsp;Each instance of Spoke
+				Rewired can have multiple organizations.
+			</p><p>
+				Organizations can be useful if your texting goals are different
+				enough to keep separate. For example, there may be overlap
+				between a volunteer contact list and a voter contact list. If
+				you send out both volunteer information and voter information,
+				your volunteers would receive both conversations from the same
+				sending number, creating a single thread in their inbox. If you
+				create one organization for volunteers and another organization
+				for voters, your volunteer could receive information from you
+				through two distinct sending numbers, thus separating those
+				conversations distinct threads.
+			</p><p>
+				Each organization is defined by a number, which is visible in
+				the URL of both
+				<a
+					href="https://docs.spokerewired.com/article/52-dashboards"
+					target="_blank">dashboards</a
+				>.
+			</p><h5><em>Each organization has a separate:</em></h5><ul>
+				<li>Pool of phone numbers for sending messages&nbsp;</li>
+				<li>Opt-out list*</li>
+			</ul><blockquote>
+				*Note: If you wish to have instance-wide, rather than
+				organization-wide, opt outs, please contact
+				support@spokerewired.com.
+			</blockquote><h4>User Permissions Across Organizations</h4><p>
+				Any user designated as a
+				<strong>Superadmin</strong>&nbsp;will be added to all new
+				organizations as an <strong>Owner.</strong> This can be useful if
+				you plan to manage many organizations on a shared Spoke instance.
+				Superadmin status must be managed directly in the database. Please
+				contact support@spokerewired.com if this is something you'd like
+				to set up.
+			</p>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-admins/reassign-conversations-to-texters.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/reassign-conversations-to-texters.astro
@@ -1,0 +1,162 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">Reassign Conversations To Texters</h2>
+
+			<p>
+				There are several ways for you to reassign conversations to new
+				texters or to unassign conversations to release them back to the
+				assignment pool. The following sections describe the various
+				methods of reassignment and unassignment.
+			</p><h2>From the Message Review page</h2><p>
+				From the Message Review page, you can manually reassign (or
+				unassign) conversations to different texters.
+			</p><p>
+				To reassign conversations from the message review page:
+			</p><ol>
+				<li>
+					Go to the <strong>Message Review</strong> page from the administration
+					dashboard.<br />
+				</li>
+				<li>
+					Filter the message list from the <strong>Message</strong>
+					<strong>Filter</strong> window. Using the filter gives you the
+					option of reassigning all conversations that match the filter.
+				</li>
+				<li>
+					Find the conversations you want to reassign, and select them
+					with the checkbox.
+				</li>
+				<li>Open the <strong>Message Actions</strong> window.</li>
+				<li>
+					Select <strong>Reassign</strong>.<br />
+					<br />
+
+					<blockquote>
+						Note: You can also select
+						<strong>Unassign</strong> to release the conversations back
+						into the assignment pool.
+					</blockquote>
+				</li>
+				<li>
+					Specify one or more texters who will receive the
+					reassignment.
+				</li>
+				<li>
+					Click <strong>Reassign selected</strong> to reassign all selected
+					contacts or <strong>Reassign all <em>n</em> matching</strong
+					> to reassign all contacts that match the filter.
+				</li>
+			</ol><p>
+				Example of how you assign initial messages (Needs First
+				Message), from a specific campaign, that are currently
+				unassigned.
+			</p><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/5f7f269546e0fb001798b0f4/file-oWwXpNydRH.png"
+				/>
+			</p><h2>From the Escalated Convos page</h2>
+			<div>
+				From the
+				<strong>Escalated Convos</strong> page of the administration <a
+					href="https://docs.spokerewired.com/article/52-dashboards"
+					target="_blank">dashboard</a
+				>, you can manually reassign (or unassign) escalated
+				conversations to texters who can handle the conversation.
+				<br />
+			</div><div>To reassign an escalated conversation:</div><ol>
+				<li>
+					Go to the <strong>Escalated Convos</strong> page from the administration
+					dashboard.
+				</li>
+				<li>
+					Select conversations for reassignment with either or both of
+					the following methods:<br />
+
+					<ol>
+						<li>
+							Filter the message list from the <strong
+								>Message</strong
+							>
+							<strong>Filter</strong> window. Using the filter gives
+							you the option of reassigning all escalated conversations
+							that match the filter.
+						</li>
+						<li>
+							Manually find the conversations you want to
+							reassign, and select them with the checkbox.
+						</li>
+					</ol>
+				</li>
+				<li>Open the <strong>Message Actions</strong> window.</li>
+				<li>
+					Select <strong>Reassign</strong>.<br />
+					<br />
+
+					<blockquote>
+						Note: You can also select
+						<strong>Unassign</strong> to release the conversations back
+						into the assignment pool.
+					</blockquote>
+				</li>
+				<li>
+					Specify one or more texters who will receive the
+					reassignment.
+				</li>
+				<li>
+					Click <strong>Reassign selected</strong> to reassign all selected
+					contacts or <strong>Reassign all <em>n</em> matching</strong
+					> to reassign all contacts that match the filter.
+				</li>
+			</ol><h2>From the Campaigns page</h2><p>
+				From the
+				<strong>Campaigns</strong> page of the administration <a
+					href="https://docs.spokerewired.com/article/52-dashboards"
+					target="_blank">dashboard</a
+				>, you can perform two <a
+					href="https://docs.spokerewired.com/article/59-campaign-actions"
+					target="_blank">campaign actions</a
+				> to release conversations.
+			</p><h4>Release Unsent Messages</h4><p>
+				The
+				<strong>Release Unsent Messages</strong>
+				<strong> </strong>campaign action releases all conversations
+				where the texter has not sent an initial message.
+			</p><p>To release unsent messages for a campaign:</p><ol>
+				<li>
+					Go to the <strong>Campaigns</strong> page from the administration
+					dashboard.
+				</li>
+				<li>
+					Open the actions menu of the campaign (the three vertical
+					dots to the right of the campaign).
+				</li>
+				<li>Click <strong>Release Unsent Messages</strong>.</li>
+			</ol><h4>Release Unreplied Conversations</h4><p>
+				The
+				<strong>Release Unreplied Conversations</strong>
+				<strong></strong>campaign action releases all conversations
+				where the texter has not sent a response to a contact.<strong
+					><br />
+				</strong>
+			</p><p>To release unreplied conversations for a campaign:</p><ol>
+				<li>
+					Go to the <strong>Campaigns</strong> page from the administration
+					dashboard.
+				</li>
+				<li>
+					Open the actions menu of the campaign (the three vertical
+					dots to the right of the campaign).
+				</li>
+				<li>Click <strong>Release Unreplied Conversations</strong>.</li>
+			</ol>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-admins/releasing-unhandled-replies.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/releasing-unhandled-replies.astro
@@ -1,0 +1,123 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">Releasing Unhandled Replies</h2>
+
+			<p>
+				Once you've built and launched a campaign and all your initial
+				messages have been sent, you may want to consider periodically
+				releasing unhandled replies from inactive texters and making
+				them available to active texters via the <a
+					href="https://docs.spokerewired.com/article/110-request-form"
+					target="_blank">request form</a
+				>. It's easy for texters to forget to check their workflows
+				regularly enough to make sure they are promptly responding to
+				all of their assigned contacts. Releasing unhandled replies
+				allows you to ensure that the people you're texting aren't
+				waiting too long to get a response!&nbsp;
+			</p><blockquote>
+				<strong>Note:</strong>Make sure you're familiar with
+				<a
+					href="https://docs.spokerewired.com/article/111-auto-assignment"
+					target="_blank">auto-assignment</a
+				> before reading this article. You will need to be using auto-assignment
+				for releasing unhandled replies to work properly.
+			</blockquote><p>
+				There are two ways to release unhandled replies: manually or
+				automatically.
+			</p><h3>Manually Releasing Unhandled Replies</h3><h4>
+				Across All Campaigns
+			</h4><p>
+				To release unhandled replies across <em>all</em>of your
+				campaigns simultaneously, go to the <strong
+					>Campaigns
+				</strong>page of your administration <a
+					href="https://docs.spokerewired.com/article/52-dashboards"
+					target="_blank">dashboard</a
+				> and click the <strong>Release Unhandled Replies</strong>button
+				in the top right hand corner.&nbsp;
+			</p><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/61131001b55c2b04bf6dd2cd/file-f4N2vwOk08.png"
+				/>
+			</p><p>
+				You'll then be prompted to choose how long conversations much
+				have been idle for in order to qualify for being released. For
+				example, if you select 1 hour, then only conversations that have
+				been waiting at least an hour for a response will be released to
+				the <a
+					href="https://docs.spokerewired.com/article/110-request-form"
+					target="_blank">request form</a
+				>, while newer conversations will remain in their existing
+				texters' workflows. This ensures that active texters are not
+				getting their conversations taken away while they're still
+				working on them! When you're ready to move forward, click
+				the&nbsp;<strong>Release</strong>&nbsp;button.
+			</p><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/6113238564a230081ba1e019/file-a0ojM0xFEE.png"
+				/>
+			</p><h4>One Campaign at a Time</h4><p>
+				To release unhandled replies on just one campaign,&nbsp;go to
+				the&nbsp;<strong>Campaigns</strong>&nbsp;page of your
+				administration <a
+					href="https://docs.spokerewired.com/article/52-dashboards"
+					>dashboard</a
+				> and&nbsp;select the three vertical dots to the right of the campaign
+				in question to pull up the menu of <a
+					href="https://docs.spokerewired.com/article/59-campaign-actions"
+					target="_blank">campaign actions</a
+				>, then select <strong style="background-color: initial;"
+					>Release Unreplied Conversations</strong
+				>. Again, you'll be prompted&nbsp;to choose how long
+				conversations much have been idle for in order to qualify for
+				being released. Choose a time and click <strong
+					style="background-color: initial;">Execute Operation</strong
+				>.
+			</p><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/611312f9b37d837a3d0e295d/file-cqod9Q2xup.png"
+				/>
+			</p><h3>Automatically Releasing Unhandled Replies</h3><p>
+				To automatically release unhandled replies to the <a
+					href="https://docs.spokerewired.com/article/110-request-form"
+					target="_blank">request form</a
+				>, go to the campaign editor page of the campaign in question
+				and open the <strong>Autoassign Mode</strong>window, then toggle
+				the <em>second</em>switch on. Again, this will prompt to
+				choose&nbsp;how long conversations much have been idle for in
+				order to qualify for being released. But in this case, Spoke
+				will <em>automatically</em>release unhandled replies according
+				to that time interval for as long as the toggle is turned on.
+				When you're ready, click <strong>Save</strong>.&nbsp;
+			</p><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/6113154c6ffe270af2a97a75/file-hDyDki3SkS.png"
+				/>
+			</p><p>
+				This option can be helpful if you want to prioritize making sure
+				your contacts get responded to as quickly as possible and when
+				it's not important for the same texter to be interacting with
+				the same contact for the duration of the conversation.&nbsp;
+			</p><p>
+				However, using this option means you'll have little real-time
+				information about how many replies you have at any one moment,
+				because they'll constantly be getting automatically unassigned.
+				Also, texters may not like getting their replies so promptly
+				taken away. If you're new to using <a
+					href="https://docs.spokerewired.com/article/111-auto-assignment"
+					target="_blank">auto-assignment</a
+				>, we recommend&nbsp;starting by manually reassigning your
+				unhandled replies and getting a feel for things before
+				experimenting with automatically releasing them.
+			</p>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-admins/request-form.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/request-form.astro
@@ -1,0 +1,64 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">Request Form</h2>
+
+			<p>
+				Texting <a
+					href="https://docs.spokerewired.com/article/33-text-assignment"
+					target="_blank">assignments</a
+				> can be easily and automatically distributed to texters using the
+				request form. The request form can be found&nbsp;at the top of a
+				texter's <a
+					href="https://docs.spokerewired.com/article/52-dashboards"
+					>dashboard</a
+				>.&nbsp;
+			</p><p style="text-align: center;">
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/5f6ba3cb52faff00174f2896/file-lPs3SGl21v.png"
+					style="background-color: initial; margin: auto; display: block;"
+					alt=""
+				/>
+			</p><p>
+				Two steps are required to assign campaign conversations via the
+				request form:
+			</p><p>
+				1. The campaign must have autoassign enabled. This can be
+				toggled on within the <strong>Autoassign Mode</strong
+				>&nbsp;window of the&nbsp;campaign settings page.
+			</p><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/5fc9400b4664bd7a123ea853/file-FVKPtDqJ8t.png"
+					alt=""
+					style="display: block; margin: auto;"
+				/>
+			</p><p>
+				2. Assignments must be enabled from the <a
+					href="https://docs.spokerewired.com/article/66-manage-assignment-control"
+					target="_blank"><strong>Assignment Control</strong></a
+				> page of the&nbsp;administration <a
+					href="https://docs.spokerewired.com/article/52-dashboards"
+					>dashboard</a
+				>. From the Assignment Control page, you can decide whether to
+				release unsent initial messages or unhandled replies. You can
+				can also set a maximum number of texts that can be requested at
+				once. Both of these options can be set individually for
+				different <a
+					href="https://docs.spokerewired.com/article/44-teams"
+					target="_blank">teams</a
+				> of texters, or for all texters at once, using the "General" designation.
+			</p><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/5fc94461d580ce55a38b41b9/file-b99REHpPfZ.png"
+				/>
+			</p>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-admins/running-a-second-pass.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/running-a-second-pass.astro
@@ -91,7 +91,7 @@ import "animate.css";
 			</p><p>
 				Choose <strong>Mark for a Second Pass</strong>&nbsp;from the
 				pop-up menu.
-			</p><p align="Center">
+			</p><p style="text-align: center;">
 				<img
 					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/5f47fb102c7d3a352e917446/file-oyvujabrQc.png"
 					style="width: 40%;"
@@ -106,7 +106,7 @@ import "animate.css";
 				oversaturation. If you choose to toggle off "exclude recently
 				texted contacts," all contacts who have not yet responded will
 				be marked for a second pass.
-			</p><p align="Center">
+			</p><p style="text-align: center;">
 				<img
 					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/5f47fdc32c7d3a352e917482/file-tcsfnEJiGw.png"
 					style="width: 80%;"
@@ -123,7 +123,7 @@ import "animate.css";
 				contacts that have been marked for a second pass. It is typical
 				for this number to be 80-90% of your initial list size,
 				depending on the window of time that you've set.&nbsp;
-			</p><p align="Center">
+			</p><p style="text-align: center;">
 				<img
 					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/5f47fe95042863444aa0eb8e/file-wbLKnZl1aF.png"
 					style="width: 80%;"
@@ -136,7 +136,7 @@ import "animate.css";
 				messages in the workflows of the original senders, therefore
 				preventing you from assigning those texts from the request
 				form.&nbsp;
-			</p><p align="Center">
+			</p><p style="text-align: center;">
 				<img
 					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/5f47ff452c7d3a352e9174a8/file-ZBlG8ps7Sj.png"
 					style="width: 40%;"

--- a/src/pages/docs/spoke/for-spoke-admins/running-a-second-pass.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/running-a-second-pass.astro
@@ -1,0 +1,150 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">Running A Second Pass</h2>
+
+			<p>
+				<a
+					href="https://drive.google.com/file/d/1r7TgIOLTZWTMkUsF-KCy7-nCuAyqYeQ-/view"
+					target="_blank"
+					style="font-family: inherit; font-size: 21px; font-weight: 700;"
+					>Second Pass 101: Watch this short demonstration video.</a
+				>
+			</p><p>
+				<a
+					href="https://drive.google.com/file/d/1r7TgIOLTZWTMkUsF-KCy7-nCuAyqYeQ-/view"
+					target="_blank"></a>Running a <strong
+					style="background-color: initial; font-size: 14px;"
+					>second pass</strong
+				>&nbsp;is a great way to politely bump your initial message to
+				non-responsive contacts. Done well, second passes see high
+				response rates, save you time, and maintain the integrity of
+				your data.
+			</p><p>To run a second pass:</p><p>
+				1. Confirm that all initial messages have been sent. This can be
+				done from <strong>Message Review</strong> by filtering for the campaign
+				name and <em>Contact message status: Needs First Message</em>.
+			</p><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/5f47f529042863444aa0ead7/file-klReBqCyzU.png"
+				/>
+			</p><p>
+				If you want to run a second pass but have outstanding initials,
+				you can quickly assign and send them without worry that those
+				contacts will be "bumped" on the second pass.&nbsp;<br />
+				<br />
+				If you were to run a second pass <em>without</em> ensuring that all
+				initials had been sent, the first message those outstanding contacts
+				would receive would be your bump message! You should either confirm
+				that all first pass initials have been sent or delete unmessaged
+				contacts before moving to step 2.
+			</p><p>
+				2. From the <strong>Basics</strong> tab of the campaign settings
+				page, update the title of your campaign to indicate that you're running
+				a second pass. This could entail adding <em>P2</em>or <em
+					>Pass 2</em
+				>&nbsp;to your campaign title, or swapping one of those out for <em
+					>P1
+				</em>or <em
+					>Pass 1.&nbsp;<br />
+					<br />
+				</em>For example, your campaign may initial be titled <em
+					>Phonebank_P1_8.26.20
+				</em>and swapped to&nbsp;<em>Phonebank_P2_8.26.20</em>before
+				running a second pass.<br />
+				<br />
+				From the&nbsp;<strong>Interactions</strong> tab of the campaign settings
+				page, replace your initial message with second pass language.&nbsp;Best
+				practices when crafting a second pass initial include removing <em
+					>{}<em>texterFirstName</em></em
+				>&nbsp;and both shortening and reiterating your previous
+				message.&nbsp;<br />
+				<br />
+				For example, for an initial message that read <em
+					>"Hi {firstName}, it's {texterFirstName} with CANDIDATE! Election
+					Day is one week away and it's all hands on deck to get CANDIDATE
+					elected. Will you join us for a phonebank on DAY at TIME and
+					help us reach every voter in DISTRICT?"
+				</em>you may consider a second pass like, <em
+					>"Hi {firstName}, just wanted to make sure you saw our first
+					message! Can you join Team CANDIDATE for a phonebank on DAY
+					at TIME?"</em
+				>
+			</p><p>
+				3. From the <strong>Campaigns</strong> page of the administration
+				<a
+					href="https://docs.spokerewired.com/article/52-dashboards"
+					target="_blank">dashboard</a
+				>, select the three dots to the right of the campaign name.
+			</p><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/5f47fae42c7d3a352e91743f/file-x3j10E3Oxt.png"
+				/>
+			</p><p>
+				Choose <strong>Mark for a Second Pass</strong>&nbsp;from the
+				pop-up menu.
+			</p><p align="Center">
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/5f47fb102c7d3a352e917446/file-oyvujabrQc.png"
+					style="width: 40%;"
+				/>
+			</p><p>
+				2. Determine a window of time to mark previously-messaged
+				contacts. You can indicate both a number of days and a number of
+				hours that have passed since a contact has last been messaged.
+				It is a best practice to mark for a second pass when a contact
+				has been messaged 16 hours ago or later; this gives contacts
+				enough time to see and respond to your message and prevents
+				oversaturation. If you choose to toggle off "exclude recently
+				texted contacts," all contacts who have not yet responded will
+				be marked for a second pass.
+			</p><p align="Center">
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/5f47fdc32c7d3a352e917482/file-tcsfnEJiGw.png"
+					style="width: 80%;"
+				/>
+			</p><p>
+				3. Determine if you'd like to exclude contacts who are present
+				on a newer campaign, regardless of whether or not they have
+				received a message yet. Toggling off "exclude contacts uploaded
+				on a newer campaign" will mark all contacts who have not yet
+				responded for a second pass, even if they are loaded on a
+				campaign with a higher ID number.
+			</p><p>
+				4. After executing the operation, you will see the number of
+				contacts that have been marked for a second pass. It is typical
+				for this number to be 80-90% of your initial list size,
+				depending on the window of time that you've set.&nbsp;
+			</p><p align="Center">
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/5f47fe95042863444aa0eb8e/file-wbLKnZl1aF.png"
+					style="width: 80%;"
+				/>
+			</p><p>
+				5. From the same three dot menu to the right of the campaign,
+				use the popup menu to select <strong
+					>Release Unsent Messages.</strong
+				>&nbsp;Skipping this step would mean leaving newly unsent
+				messages in the workflows of the original senders, therefore
+				preventing you from assigning those texts from the request
+				form.&nbsp;
+			</p><p align="Center">
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/5f47ff452c7d3a352e9174a8/file-ZBlG8ps7Sj.png"
+					style="width: 40%;"
+				/>
+			</p><p>
+				6.&nbsp;Confirm that your campaign is on Autoassign and that the
+				request form is set to Initial Messages, or manually assign the
+				new initial messages in Message Review!
+			</p>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-admins/running-a-second-pass.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/running-a-second-pass.astro
@@ -63,19 +63,20 @@ import "animate.css";
 				From the&nbsp;<strong>Interactions</strong> tab of the campaign settings
 				page, replace your initial message with second pass language.&nbsp;Best
 				practices when crafting a second pass initial include removing <em
-					>{}<em>texterFirstName</em></em
+					>&lcub;&rcub;<em>texterFirstName</em></em
 				>&nbsp;and both shortening and reiterating your previous
 				message.&nbsp;<br />
 				<br />
 				For example, for an initial message that read <em
-					>"Hi {firstName}, it's {texterFirstName} with CANDIDATE! Election
-					Day is one week away and it's all hands on deck to get CANDIDATE
-					elected. Will you join us for a phonebank on DAY at TIME and
-					help us reach every voter in DISTRICT?"
+					>"Hi &lcub;firstName&rcub;, it's &lcub;texterFirstName&rcub;
+					with CANDIDATE! Election Day is one week away and it's all
+					hands on deck to get CANDIDATE elected. Will you join us for
+					a phonebank on DAY at TIME and help us reach every voter in
+					DISTRICT?"
 				</em>you may consider a second pass like, <em
-					>"Hi {firstName}, just wanted to make sure you saw our first
-					message! Can you join Team CANDIDATE for a phonebank on DAY
-					at TIME?"</em
+					>"Hi &lcub;firstName&rcub;, just wanted to make sure you saw
+					our first message! Can you join Team CANDIDATE for a
+					phonebank on DAY at TIME?"</em
 				>
 			</p><p>
 				3. From the <strong>Campaigns</strong> page of the administration

--- a/src/pages/docs/spoke/for-spoke-admins/script-preview.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/script-preview.astro
@@ -1,0 +1,48 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">Script Preview</h2>
+
+			<p>
+				Script preview allows you to see a campaign's <a
+					href="https://docs.spokerewired.com/article/38-interaction-scripts"
+					target="_blank">interaction script</a
+				> and <a
+					href="https://docs.spokerewired.com/article/47-canned-responses"
+					target="_blank">canned responses</a
+				> in a clean and organized format. This can be helpful to have open
+				on a separate tab as you build your campaigns, if you need to share
+				your campaign with another team member to get feedback or approval
+				on a script, or if you want to give your texters a more holistic
+				view of the campaign they're working on.
+			</p><h5><em>To access the script preview for a campaign:</em></h5><p
+			>
+				1. Select the campaign from the <strong>Campaigns</strong>page
+				of the<strong>&nbsp;</strong>administration <a
+					href="https://docs.spokerewired.com/article/52-dashboards"
+					target="_blank">dashboard</a
+				>.
+			</p><p>
+				2. Click <strong>Open Script Preview</strong>. This will
+				automatically open the preview in a new tab in your browser.
+			</p><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/60087236c64fe14d0e1fcc5a/file-RVcQmnRjjL.png"
+					alt=""
+					style="display: block; margin: auto;"
+				/>
+			</p><h4>Here's an example script preview:</h4><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/600873861c64ad47e4b71207/file-m45W7Oe3MY.png"
+				/>
+			</p>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-admins/segments-and-encodings.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/segments-and-encodings.astro
@@ -1,0 +1,84 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">Segments And Encodings</h2>
+
+			<p>
+				In Spoke, SMS messages are billed by the
+				<strong>segment</strong>, rather than the whole message.&nbsp;To
+				learn about MMS messages, scroll to the MMS section below.
+			</p><h4><strong>What is a segment?</strong></h4><p>
+				A segment is a component of a larger overall text message. You
+				can think of it as a single page in a letter. You can read more
+				about segments
+				<a
+					href="https://www.twilio.com/blog/2017/03/what-the-heck-is-a-segment.html"
+					>here</a
+				>.&nbsp;
+			</p><p>
+				Most of the time, an SMS segment can be up to 160 characters. An
+				SMS message under 160 characters will often be one segment,
+				while a message between 160 and 320 characters will be 2
+				segments.&nbsp;
+				<br />
+				<br />
+				However, depending on the characters present in your message, your
+				message may be encoded differently. Encoding can affect the number
+				of characters that networks can fit into a single segment.
+			</p><h4><strong>What is character encoding?</strong></h4><p>
+				The most common and efficient character encoding is called
+				<em>GSM.</em> Most standard characters will be able to be encoded
+				using GSM encoding. If you use certain characters like emojis (e.g.,&nbsp;<strong
+					>🙂</strong
+				>), non-English characters (e.g. <em>í, ü</em>), or certain
+				punctuation (e.g. <em>`, –</em>), your message will require
+				Unicode character encoding. Unicode is limited to 70 characters
+				per segment.
+			</p><h4><strong>Segments within Spoke</strong></h4><p>
+				To help you keep track of the number of segments you're sending,
+				we've added a segment counter that also informs you of the
+				character set with which your message is likely to be encoded.
+				This counter is only relevant for SMS messages, not MMS.
+				<br />
+				For example, when typing an emdash (&mdash;), you can see the character
+				set switch to Unicode and the segment count and characters left adjust
+				accordingly:
+			</p><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/5ea1bdee04286364bc98e446/file-oLo299bMdf.png"
+					alt="GSM Encoded Message"
+					style="display: block; margin: auto;"
+				/>
+			</p><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/5ea1be602c7d3a7e9aeb8352/file-EEtCIm0orL.png"
+					alt="Unicode Encoded Message"
+					style="display: block; margin: auto;"
+				/>
+			</p><h4>Segments within Spoke exports</h4><p>
+				By using the
+				<em>Export Data</em>&nbsp;button from the individual campaign
+				page, you&nbsp;will be emailed two links to download your data
+				exports. The second of these is your <em>messages export</em>,
+				where you can find a breakdown of the number of segments on a
+				particular campaign. For a more robust segment breakdown, please
+				email support@spokerewired.com.&nbsp;
+			</p><h3>How is MMS different?</h3><p>
+				Unlike SMS, MMS pricing does not take into consideration the
+				number of characters. When you include an image with your text,
+				the entire text will be priced at our MMS price of $0.03,
+				regardless of length.&nbsp;
+			</p><p>
+				<strong>Note:</strong> Spoke has a universal limit of 1600 characters
+				for any text.
+			</p>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-admins/send-status-and-error-codes.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/send-status-and-error-codes.astro
@@ -1,0 +1,85 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">Send Status And Error Codes</h2>
+
+			<h3>Send Status</h3><p>
+				<em>Send status</em> is a column within the messages export from
+				Spoke. It refers to the status of an outbound message (inbound messages
+				are always DELIVERED).
+			</p><p>
+				There are 3 possible values for send status: <strong
+					>SENT,</strong
+				>&nbsp;<strong>DELIVERED,</strong>and <strong>ERROR</strong>.
+			</p><h4>ERROR</h4><p>
+				A send status of <strong>ERROR</strong>&nbsp;means that the
+				message was <strong>not delivered</strong> to the recipient's phone.
+				Most commonly, this occurs when the recipient's carrier rejects the
+				message as part of their spam filter. This often happens when your
+				message has included links or URLs. To read about methods of increasing
+				deliverability of links, see <a
+					href="https://docs.spokerewired.com/article/113-sending-links"
+					target="_blank">here</a
+				> and <a
+					href="https://docs.spokerewired.com/article/70-short-link-domains"
+					target="_blank">here</a
+				>.
+			</p><p>
+				You may also see an ERROR send status for a contact who has
+				replied "STOP" or "UNSUBSCRIBE" in the past. Don't worry &mdash;
+				You won't be charged for messages rejected for this particular
+				reason (you <em>are</em> charged for messages rejected by carriers
+				for other reasons). It is considered best practice to send an opt-out
+				confirmation message, according to the official CTIA guidelines.
+			</p><h4>DELIVERED</h4><p>
+				A send status of <strong>DELIVERED</strong>&nbsp;means that
+				Spoke <strong>received confirmation</strong> that the message was
+				delivered to the recipient's phone. Almost all of the time, this
+				means that the recipient's phone received the message. Some of the
+				time, however, carriers choose to send affirmative delivery reports
+				<em>without</em> having sent the message; this typically occurs after
+				sending a large volume of a particular URL, and it's likely that
+				they do it in order to prevent you or us from reverse-engineering
+				their spam filters.
+			</p><h4>SENT</h4><p>
+				A send status of&nbsp; <strong
+					style="background-color: initial;">SENT</strong
+				>&nbsp;means that the message was just sent by the user and is <strong
+					style="background-color: initial;"
+					>in the process of being delivered</strong
+				>. This is most often a temporary status, and you'll see many
+				messages marked as SENT if you export from a currently-running
+				campaign. Delivery reports typically arrive in a few seconds,
+				but some arrive minutes or hours later. That said, a small
+				percent of messages will stay SENT for all time. This means that
+				we never received a delivery report from the carrier. Like
+				false-positive delivery reports, this just happens sometimes and
+				is likely done to prevent the reverse-engineering of spam
+				filters.
+			</p><h3>Error Codes</h3><p>
+				<em>Error code</em> is a column on the messages export from Spoke.
+				It refers to the error codes that we receive from underlying telecom
+				providers (expressed as stringified 5-digit integers).&nbsp;
+			</p><p>
+				Error codes are specific to the service that is powering your
+				instance of Spoke, which at the moment is either <a
+					href="https://developers.telnyx.com/docs/api/v2/overview#error-codes"
+					target="_blank">Telnyx</a
+				>, <a
+					href="https://www.twilio.com/docs/api/errors#1-anchor"
+					target="_blank">Twilio</a
+				>, or <a
+					href="https://dev.bandwidth.com/docs/messaging/errors/"
+					target="_blank">Bandwidth</a
+				>.
+			</p>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-admins/sending-links.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/sending-links.astro
@@ -1,0 +1,50 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">Sending Links</h2>
+
+			<p>
+				Sending links in your messages increases the likelihood they
+				will be flagged as spam and blocked by cell carriers.
+			</p><h5>
+				<em
+					>To minimize the chance your texts get blocked by carriers:<br
+					/>
+				</em>
+			</h5><p>
+				1. Avoid sending links in initial messages. Instead, make a
+				clear and direct ask in your initial message and then include
+				the link in your <strong>Yes</strong> and <strong>Maybe</strong>
+				survey responses to those who express interest. This will dramatically
+				lower the total number of links you are sending.
+			</p><p>
+				2. Use unique long links (like a candidate website, Secretary of
+				State website, or a voter lookup tool) or a custom short link
+				(like one created with a purchased custom domain from <a
+					href="https://www.rebrandly.com/"
+					target="_blank">Rebrandly</a
+				>). When using a custom short link, we recommend using&nbsp;<em
+					>.me</em
+				> or <em>.us</em> to make a domain like&nbsp;<em>rewired.us</em>
+			</p><p>
+				3. Do not use links with common domains (like ActBlue, Google,
+				etc.) or URLs created with&nbsp;common link shorteners (like
+				bit.ly or tinyurl.com).
+			</p><p>
+				4. If you're planning to send the same link to large numbers of
+				contacts, consider using script options and custom domains to
+				rotate your links. You can read more about this feature <a
+					href="https://docs.spokerewired.com/article/70-short-link-domains"
+					>here</a
+				>.&nbsp;
+			</p>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-admins/settings.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/settings.astro
@@ -1,0 +1,64 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">Settings</h2>
+
+			<p>
+				The following settings apply to all campaigns in your Spoke
+				organization. You can access these <strong>Settings</strong> from
+				the administrator
+				<a
+					href="https://docs.spokerewired.com/article/52-dashboards"
+					data-bcup-haslogintext="no">dashboard</a
+				>.
+			</p><h2>Default Text Request Auto-Approval Level</h2><p>
+				Choose the default assignment-approval setting for new
+				texters.&nbsp;To expedite the assignment process, we typically
+				recommend setting the default to Auto Approve. Though no matter
+				the default assignment-approval level, you can modify an
+				individual texter's approval level from the
+				<strong style="background-color: initial;">People</strong> tab on
+				the lefthand side admin panel.&nbsp;
+			</p><h2>Opt-Out Message</h2>
+			<div>
+				You can set the default opt-out message that auto-populates the
+				message field when texters use the opt-out feature.
+				<br />
+			</div><h2>Texting Hours</h2><p>
+				You can enforce
+				<a
+					href="https://docs.spokerewired.com/article/48-texting-hours"
+					data-bcup-haslogintext="no"
+					target="_blank">texting hours</a
+				> across all campaigns by turning on this feature. This prevents
+				you from disturbing contacts outside of these hours. Each campaign
+				has its own set of texting hours that you specify on the campaign
+				settings page.
+			</p><h2>Assemble Numbers API key</h2><p>
+				Assemble Numbers is a service that helps you determine whether
+				you can reach a phone number in your contact list. This API key
+				field is populated by default and allows you to use the
+				<em>Filter Landlines</em> feature within the campaign settings page.
+			</p><h2>Contact Information Display</h2><p>
+				For some specific use cases (e.g., volunteer or member contact)
+				it may be desirable to show the contact's last name and/or cell
+				phone to the texter. The toggles in this section allow you to do
+				that.
+			</p><blockquote>
+				<em
+					>Note: Think carefully about the privacy implications of
+					exposing this information before you enable these options!
+					We strongly dissuade you from using it under most
+					circumstances.</em
+				>
+			</blockquote>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-admins/short-link-domains.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/short-link-domains.astro
@@ -1,0 +1,99 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">Short Link Domains</h2>
+
+			<h3>What is a Short Link Domain?&nbsp;</h3><p>
+				A short link domain is a&nbsp;<b
+					style="background-color: initial;">shorter</b
+				>&nbsp;version of a URL you intend to share.
+			</p><p>
+				Custom short link domains let you minimize the chance that your
+				messages with links are blocked by carriers. Commonly used short
+				links&nbsp;(e.g., bit.ly, tinyurl.com, etc.) as well as commonly
+				used link domains (e.g., ActBlue, Mobilize, ActionKit)&nbsp;are
+				some of the more common reasons that carriers choose to block
+				messages, which they interpret as spam.
+			</p><p>
+				When trying to send out links of this type, some clients have
+				found success using the link shortening service <a
+					href="https://www.rebrandly.com/">Rebrandly</a
+				>. However, it's important (and worthwhile) that you buy a
+				custom domain from them rather than using their default domain
+				of <em>rebrand.ly</em>. Links that say rebrand.ly, bit.ly, or
+				tiny.url in them perform poorly. Create a custom domain using
+				.me, .us, or another less common URL suffix and name the domain
+				something legible, like rewired.us. Purchasing a domain can cost
+				as little as $2 and will boost your deliverability
+				considerably.&nbsp;
+			</p><p>
+				For even further deliverability assurance, use script versions
+				to rotate links. In the interactions section of your campaign
+				builder, click ADD SCRIPT VERSION. Using <a
+					href="https://www.rebrandly.com/">Rebrandly</a
+				>, you can set up multiple short links to send out the same
+				link. See our example below using the links
+				GNDchampion.me/1,&nbsp;GNDchampion.me/2, and GNDchampion.me/3.
+				While these example links all lead to the same donate page,
+				having 3 script versions will alternate which link is sent out,
+				improving deliverability.&nbsp;
+			</p><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/6324b9611ec1962d58a80219/file-TWi5qCgDn4.jpg"
+				/>
+			</p><p>
+				<em>
+					For more information, contact support@spokerewired.com.</em
+				>
+			</p><h3>Setting up Rotating Short Link Domains in Spoke&nbsp;</h3><p
+			>
+				<em
+					><strong
+						>UPDATE: "Short Link Domains" is no longer a default
+						Spoke feature, but we can enable this feature if your
+						organization is texting out 50,000-100,000 messages per
+						day with links and is running into deliverability
+						issues.&nbsp;</strong
+					></em
+				><em style="background-color: initial;"
+					>If you think this would be a good solution for your use
+					case, please email support@spokerewired.com</em
+				>
+			</p><p>
+				You can add to a list of short link domains from the
+				administration <a
+					href="https://docs.spokerewired.com/article/52-dashboards"
+					target="_blank">dashboard</a
+				>. When a texter sends a message that includes a shortened link,
+				Spoke uses this list to automatically detect and replace the
+				short link's domain with another domain in the list. Spoke
+				cycles through the domains in this list to spread out usage of
+				the domains. The <em>maximum</em><em>usage</em> setting for a domain
+				specifies the number of times Spoke will use that domain before moving
+				onto the next one.
+			</p><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/5eea2dc82c7d3a10cba913ba/file-QtinuDJH8t.png"
+				/>
+			</p><p>
+				You must set up the short links outside of the Spoke platform,
+				and they must resolve to the same end location for the domain
+				replacement to work. Spoke can detect only the domains you've
+				added to the short&nbsp;link domain list; URLs with other
+				domains will not be replaced.
+			</p><blockquote>
+				<strong>Note:</strong> If you don't set up short links outside of
+				the platform, the links you send out will not work as expected. If
+				you have questions or concerns, contact&nbsp;support@spokerewired.com.
+				<br />
+			</blockquote>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-admins/spoke-101-tips-for-a-successful-mass-text.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/spoke-101-tips-for-a-successful-mass-text.astro
@@ -1,0 +1,84 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">
+				Spoke 101 Tips For A Successful Mass Text
+			</h2>
+
+			<p>
+				If you need help getting started, click <a
+					href="https://docs.spokerewired.com/article/34-build-a-campaign"
+					>here</a
+				> to read about how to build a campaign. Once you have created a
+				draft campaign, check to make sure your campaign meets the following
+				characteristics to make sure your messages are delivered and not
+				filtered as spam.
+			</p><p><strong>What is spam filtering?</strong></p><p>
+				When your texts leave Spoke, they travel through a chain of
+				other channels before arriving at someone&#39;s cell phone. At
+				any stop along the way, your message can be deemed spam and thus
+				not delivered.
+			</p><br /><p>
+				How can you make sure to construct a message that will reach
+				your audience?
+			</p><ul>
+				<li>
+					<strong>Use short-links.</strong> Commonly used short
+					links (e.g., bit.ly, tinyurl.com, etc.) as well as commonly
+					used link domains (e.g., ActBlue) are OFTEN blocked as spam.
+					We recommend using a custom domain on <a
+						href="https://www.rebrandly.com/">Rebrandly</a
+					>. See our full article <a
+						href="https://docs.spokerewired.com/article/70-short-link-domains"
+						>here</a
+					> for more info.
+				</li><li>
+					<strong>Introduce yourself.</strong>Greet the textee and
+					identify who you are and from what organization you&#39;re
+					texting. This could look like &quot;Hey {firstName}, {
+						texterFirstName
+					} here with Politics Rewired!&quot;
+				</li><li>
+					<strong>End your message with opt out language.</strong> &#39;Reply
+					STOP to quit&#39; is a safe bet. We also like (STOP to End).
+					This is crucial for deliverability.
+				</li><li>
+					<strong>Ensure grammar and punctuation are correct.</strong>
+					Messages with incorrect grammar are likely to be filtered out.
+				</li>
+			</ul><p>MMS checklist:</p><ul>
+				<li>
+					<strong>Is the image under 600kb?</strong> Images above 600kb
+					in size will not deliver to many cell phones.
+				</li><li>
+					<strong
+						>Make sure the link is a link directly to the image</strong
+					> and ends in .jpeg, .png, or .gif.
+				</li><li>
+					<p>
+						<strong
+							>Put your image link in square brackets to send MMS.
+						</strong>There should not be a space between the
+						brackets and the initial text, so there is no odd space
+						at the beginning of your message.
+					</p><br /><p>
+						To review, an MMS initial message should look like the
+						following:
+					</p>
+				</li>
+			</ul><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/630fc1d14cde766bbe140f56/file-ypwDxzwcGO.png"
+					style="max-width: 100%; "
+				/>
+			</p>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-admins/spoke-101-tips-for-a-successful-mass-text.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/spoke-101-tips-for-a-successful-mass-text.astro
@@ -42,9 +42,9 @@ import "animate.css";
 				</li><li>
 					<strong>Introduce yourself.</strong>Greet the textee and
 					identify who you are and from what organization you&#39;re
-					texting. This could look like &quot;Hey {firstName}, {
-						texterFirstName
-					} here with Politics Rewired!&quot;
+					texting. This could look like &quot;Hey
+					&lcub;firstName&rcub;, &lcub; texterFirstName &rcub; here
+					with Politics Rewired!&quot;
 				</li><li>
 					<strong>End your message with opt out language.</strong> &#39;Reply
 					STOP to quit&#39; is a safe bet. We also like (STOP to End).

--- a/src/pages/docs/spoke/for-spoke-admins/survey-responses-vs-canned-responses.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/survey-responses-vs-canned-responses.astro
@@ -1,0 +1,76 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">Survey Responses Vs Canned Responses</h2>
+
+			<p>
+				One of most common mistakes made by Spoke users is to mix up the
+				use of
+				<strong>survey responses</strong>&nbsp;and <strong
+					>canned responses</strong
+				> when building campaign scripts. Using each feature correctly will
+				ensure that you have easy-to-navigate scripts that log all the data
+				you want to capture. Using them incorrectly may result in loss of
+				data and a frustrating experience for your texters.
+			</p><h3>Survey Responses</h3><p>
+				Survey Responses constitute the core building blocks of your
+				campaigns. Creating survey responses in your
+				<a
+					href="https://docs.spokerewired.com/article/43-create-interaction-script"
+					>Interaction Script</a
+				> allows your texters to select a from a menu of survey responses
+				while in a texting conversation, each with it's own prepared script.
+				Once the survey response is selected and sent, the texter is also
+				simultaneously logging data about how that contact responded. In
+				other words, <strong
+					>survey responses combine the functions of providing a
+					ready-made script for your texters and logging data about
+					the conversation.
+				</strong>Therefore, in order to both log data and make life
+				easier for your texters, the vast majority of your campaign's
+				responses should typically be built into your Interaction Script
+				as survey responses.
+			</p><p>
+				For example, if you're asking a Yes/No question in your initial
+				message, then "Yes,"&nbsp;"No," and "Maybe" should all be
+				different survey responses. Similarly, if you're gauging support
+				for a candidate using a 1-5 Voter ID score, then you should have
+				five different survey responses, one for each level of support
+				(see example survey response scripts
+				<a
+					href="https://docs.spokerewired.com/article/120-writing-scripts"
+					>here</a
+				>). Note that in addition to generating useful scripts for your
+				texters, it would be critical to capture the data on how
+				contacts answered these questions.
+			</p><h3>Canned Responses</h3><p>
+				Canned Responses constitute a supplemental menu of common
+				answers to common questions that your texters may encounter.
+				Applying a canned response to a conversation does
+				<em>not</em>log any data about that conversation. Therefore, <strong
+					>c</strong
+				><strong
+					>anned responses should <em>only</em> be used to answer questions
+					where you don't care about collecting data.&nbsp;</strong
+				>
+			</p><p>
+				Below are some common examples of canned responses. Note that
+				answering these questions would provide the contact with
+				important information, but it wouldn't typically be important to
+				log data indicating that they asked the question.
+			</p><ul>
+				<li>Where did you get my information?</li>
+				<li>What is {organization_name}?</li>
+				<li>How do I check if I'm registered to vote?</li>
+				<li>Where is my polling place?</li>
+			</ul>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-admins/survey-responses-vs-canned-responses.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/survey-responses-vs-canned-responses.astro
@@ -67,7 +67,7 @@ import "animate.css";
 				log data indicating that they asked the question.
 			</p><ul>
 				<li>Where did you get my information?</li>
-				<li>What is {organization_name}?</li>
+				<li>What is &lcub;organization_name&rcub;?</li>
 				<li>How do I check if I'm registered to vote?</li>
 				<li>Where is my polling place?</li>
 			</ul>

--- a/src/pages/docs/spoke/for-spoke-admins/tags.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/tags.astro
@@ -1,0 +1,87 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">Tags</h2>
+
+			<p>
+				Tags are used by texters to log additional data about a
+				conversation or contact. Tags can be applied to any conversation
+				across all of your organization's campaigns and are typically
+				used to capture information that doesn't fit neatly in your
+				interaction scripts.&nbsp;
+			</p><p>
+				For example, a
+				<em>Spanish</em>&nbsp;tag would allow you to mark people
+				replying in Spanish as Spanish-speakers, giving you the
+				information needed to contact them in the future in their
+				preferred language. A <em>Volunteer Lead</em>&nbsp;would allow
+				you to&nbsp;mark people expressing interest in volunteering,
+				enabling you to follow up and recruit them later.
+			</p><blockquote>
+				<em
+					>Note: Conversation tags apply only to the current
+					conversation and do carry over to conversations with the
+					same contact on other campaigns.</em
+				>
+			</blockquote><h5><em>To create a tag:</em></h5><ol>
+				<li>
+					Navigate to the <strong>Tags</strong>page page of the
+					administration <a
+						href="https://docs.spokerewired.com/article/52-dashboards"
+						target="_blank">dashboard</a
+					>.&nbsp;
+				</li>
+				<li>
+					Click the green&nbsp;<strong>plus (+)</strong> button in the
+					bottom right-hand corner.
+				</li>
+				<li>Choose a <strong>tag title</strong>.</li>
+				<li>
+					<em>Optional –&nbsp;</em>You may also include a <strong
+						>tag description</strong
+					>, a&nbsp;<strong>tag script</strong> that will automatically
+					populate when the tag is selected by a texter, as well as the
+					tag's<strong>&nbsp;text&nbsp;color</strong> and <strong
+						>background color</strong
+					>.&nbsp;
+				</li>
+				<li>Click <strong>Create</strong>.</li>
+			</ol><h4>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/601dd97dfb34b55df443df5d/file-ev0KNerJ8c.png"
+				/>Custom Escalation Tags
+			</h4><p>
+				You can also create a custom escalation tag that not only logs
+				data but removes the conversation from a texter's workflow, and
+				makes it uniquely available to a specialized <a
+					href="https://docs.spokerewired.com/article/49-create-a-team"
+					target="_blank">team</a
+				> for assignment.&nbsp;To do this, just un-check <strong
+					style="background-color: initial;"
+					>Allow assignment
+				</strong>when creating your tag.
+			</p><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/601dafc81f25b9041bebc15e/file-3jd35mrmiS.png"
+				/>
+			</p><p>
+				You can then apply these custom escalation tags to a specialized
+				team of texters by navigating to
+				<strong>Assignment Control</strong> and&nbsp; adding the tag to the&nbsp;<strong
+					>Custom escalation&nbsp;tag
+				</strong>field.
+			</p><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/601ddd326867724dfc6f04b1/file-uI6D5H8bK5.png"
+				/>
+			</p>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-admins/text-assignment.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/text-assignment.astro
@@ -1,0 +1,86 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">Text Assignment</h2>
+
+			<p>
+				Assignments are discrete batches of text messages
+				(conversations) to be allocated to texters. There are two
+				different ways to assign conversations to texters: manually or
+				automatically.&nbsp;
+			</p><h2>Manual Assignment</h2><p>
+				Administrators can manually assign texts to individual texters
+				from either the <strong>Texters</strong>window of the campaign
+				settings page or from the <strong>Message Review</strong> page off
+				of the&nbsp;administration <a
+					href="https://docs.spokerewired.com/article/52-dashboards"
+					target="_blank">dashboard</a
+				>. Depending on how many texters you are managing with manual
+				assignment, this can be a very time-intensive process. We
+				typically recommend using auto-assignment, unless you have a
+				special case that requires manual assignment.
+			</p><h2>Auto-Assignment</h2><p>
+				<a
+					href="https://docs.spokerewired.com/article/111-auto-assignment"
+					target="_blank">Auto-assignment</a
+				> allows texters to request a preset number of conversations (either
+				initial messages or unhandled replies) from the <a
+					href="https://docs.spokerewired.com/article/110-request-form"
+					target="_blank">request form</a
+				> on the texter <a
+					href="https://docs.spokerewired.com/article/52-dashboards"
+					target="_blank">dashboard</a
+				>.&nbsp;
+			</p><p>
+				Auto-assignment can be set up two different ways:&nbsp;
+			</p><ol>
+				<li>
+					<strong>Approval Required:</strong>Where each assignment
+					request must be manually approved by an Administrator or <a
+						href="https://docs.spokerewired.com/article/6-user-roles"
+						target="_blank">Supervolunteer</a
+					> in order for texters to receive their texts.
+				</li>
+				<li>
+					<strong>Auto Approve:</strong>Where requested assignments
+					are automatically approved, allowing texters to start
+					texting contacts within moments of submitting their request.
+				</li>
+			</ol><p>
+				Determine the default setting for auto-assignment in the <strong
+					>Settings</strong
+				> page of&nbsp;the&nbsp;administration dashboard.&nbsp;
+			</p><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/5fc6a179d580ce55a38b3410/file-jKIfkJUxR2.png"
+				/>
+			</p><p>
+				To expedite the assignment process, we typically recommend
+				setting the default to Auto Approve.&nbsp;You can also edit
+				the&nbsp;auto-assignment setting of a specific texter in
+				the&nbsp;<strong>People</strong>&nbsp;page
+				of&nbsp;the&nbsp;administration dashboard.
+			</p><p>
+				Once you've set the default setting for auto-assignment, you can
+				enable autoassign for specific campaigns&nbsp;within the <strong
+					>Autoassign Mode</strong
+				>&nbsp;window of the&nbsp;campaign settings page. You can then
+				release texting assignments from those campaigns to your texters
+				via the <a
+					href="https://docs.spokerewired.com/article/110-request-form"
+					target="_blank">request form</a
+				>, using the <a
+					href="https://docs.spokerewired.com/article/66-manage-assignment-control"
+					target="_blank"><strong>Assignment Control</strong></a
+				> page of the&nbsp;administration dashboard.
+			</p><h2></h2>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-admins/texting-hours.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/texting-hours.astro
@@ -1,0 +1,39 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">Texting Hours</h2>
+
+			<p>
+				Texting hours restrict when <a
+					href="https://docs.spokerewired.com/article/6-user-roles"
+					>texters</a
+				> can send messages to contacts. Using texting hours minimizes the
+				chance of disturbing someone at inappropriate hours of the day. Spoke's
+				default texting hours have been chosen to comply with regulations
+				regarding consumer telephone contact. <strong
+					>We do not recommend extending these hours</strong
+				> and you do so at your own risk.
+			</p><p>
+				Texting hours are defined in the <a
+					href="https://docs.spokerewired.com/article/34-create-a-campaign"
+					target="_blank">campaign settings page</a
+				> by a start time, an end time, and a default time zone. The time
+				zone for a contact is determined by their zip code. If a contact
+				does not have a zip code, the default time zone is used.
+			</p><p>
+				Outside of texting hours, Spoke disables the <strong
+					>Send</strong
+				> and <strong>Send Replies</strong> buttons in the texter's workflow.
+				If you try to send a message outside of the designated texting hours,
+				the text will not send, and you'll receive an error.
+			</p>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-admins/transitioning-to-10dlc.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/transitioning-to-10dlc.astro
@@ -1,0 +1,217 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">Transitioning To 10dlc</h2>
+
+			<h1>Brand and Campaign Registration Guide</h1><p>
+				Spoke Rewired fully supports sending messages with 10DLC. To
+				take advantage of our lowest prices and improved deliverability,
+				you should register your Spoke organization for a 10DLC brand.
+			</p><p>
+				We are committed to supporting you throughout the registration
+				process and offer registration and ongoing 10DLC enrollment at
+				no additional cost.
+			</p><p>
+				You can find the registration link in the Admin section of your
+				Spoke Rewired instance. Navigate to Settings and click Register
+				under the heading &quot;10DLC Registration Information.”
+			</p><h2>Guide Summary</h2><p>
+				There are two parts to completing 10DLC registration. The first
+				part is for 527 political organizations only (e.g., campaign or
+				PAC) and the second part is for all organizations including
+				527s. If you are not a 527 political organization you can <a
+					href="#10DLC-Registration-dQyXs"
+					target="_blank">skip to 10DLC registration.</a
+				>
+			</p><ul>
+				<li>
+					<a
+						href="#Campaign-Verify-Registration-GO_24"
+						target="_blank">Campaign Verify Registration</a
+					><ul><li>527 political organizations only</li></ul>
+				</li><li>
+					<a href="#10DLC-Registration-dQyXs" target="_blank"
+						>10DLC Registration in Spoke</a
+					><ul><li>For all organizations including 527s</li></ul>
+				</li>
+			</ul><h2 id="Campaign-Verify-Registration-GO_24">
+				Campaign Verify Registration
+			</h2><p>
+				Verification for 527 political organizations (e.g., campaign or
+				PAC) is handled by <a
+					href="https://www.campaignverify.org/"
+					target="_blank">Campaign Verify</a
+				>. If you qualify, you should begin the registration process
+				with Campaign Verify ASAP! Please note that campaigns that
+				registered before November 15th, 2022, will need to resubmit
+				using a new Campaign Verify Token. As per Campaign Verify:
+			</p><blockquote>
+				<p>
+					Authorization Tokens for verification requests submitted on
+					November 15, 2022 and later will be valid until January 31,
+					2025.
+				</p>
+			</blockquote><p>
+				<strong>Steps to register a 527 political organization:</strong>
+			</p><ol>
+				<li>
+					Register with Campaign Verify by filling out the <a
+						href="https://www.campaignverify.org/#signup"
+						target="_blank">Campaign Verify form</a
+					>.<ul>
+						<li>
+							Step-by-step instructions can be found on the <a
+								href="https://www.campaignverify.org/our-process"
+								target="_blank">Campaign Verify website here</a
+							>.
+						</li>
+					</ul>
+				</li>
+			</ol><p style="text-align: center;" class="align-center">
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/64879ca8969cec658daaf7f0/file-4VE9Xx8yoZ.png"
+					style="width: 100%; max-width: 100%; text-align: center;"
+				/>
+			</p><ol start="2">
+				<li>
+					Receive an Authorization Token from Campaign Verify.<ul>
+						<li>
+							Example token:<code class="inline-code"
+								>cv|1.0|tcr|10dlc|00000000-0000-4000-0000-000000000000|abca1b2c3d4e5f6g7h8i9j0_0000000000000000000</code
+							>
+						</li>
+					</ul>
+				</li><li>
+					Once you receive the Campaign Verify Authorization Token,
+					continue by following the steps below to register for 10DLC
+					in your Spoke instance.
+				</li>
+			</ol><h2 id="10DLC-Registration-dQyXs">
+				10DLC Registration in Spoke
+			</h2><p>
+				All organizations including 527 political organizations must
+				fill out this form to finish 10DLC registration. <b
+					><i
+						>Note: Only users with the Owner role will be able to
+						complete registration.</i
+					></b
+				>
+			</p><ol>
+				<li>
+					From your <a
+						href="https://docs.spokerewired.com/article/52-dashboards"
+						target="_blank">administration dashboard</a
+					>, navigate to &quot;Settings&quot; in the left menu
+				</li>
+			</ol><p style="text-align: center;" class="align-center">
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/64879f041211660f0912d895/file-SFrHMa99fl.png"
+					style="width: 42.1628%; max-width: 100%; text-align: center;"
+				/>
+			</p><ol start="2">
+				<li>
+					From the Settings page, click the &quot;Register&quot;
+					button.
+				</li>
+			</ol><p style="text-align: center;" class="align-center">
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/6487a1335fc2fe6b6dc5fcd8/file-4UrQH5f5YK.png"
+					style="width: 100%; max-width: 100%; text-align: center;"
+				/>
+			</p><ol start="3">
+				<li>
+					Fill out the 10DLC registration form for Rewired LLC and
+					submit. Email us at <a
+						href="mailto:support@politicsrewired.com"
+						>support@spokerewired.com</a
+					> with any questions.
+				</li>
+			</ol><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/6487a1da7f8c2575e3544c18/file-PK4h6HfuNf.png"
+					style="width: 100%; max-width: 100%; "
+				/>
+			</p><ol start="4">
+				<li>
+					Note: Customers that signed up for our service before
+					October 1st, 2021 may need to sign the newest contract if
+					they have not already. We will email your account owner the
+					new contract. The updated service agreement covers 10DLC
+					changes, including <a
+						href="https://docs.spokerewired.com/article/129-10dlc-pricing"
+						target="_blank">10DLC Pricing and Compliance</a
+					>. We will not register a <a
+						href="https://docs.spokerewired.com/article/131-10dlc-glossary"
+						target="_blank">brand</a
+					> or campaign on your behalf until the updated service agreement
+					has been signed and we have the required brand registration information.
+				</li>
+			</ol><p>
+				We anticipate a 3-5 business day delay between completing the
+				registration and your brand being capable of sending messages.
+			</p><br /><h3>Message Limitations for Sole Proprietorships</h3><p>
+				Mobile carriers limit message volume if you are a sole
+				proprietor or have no legal entity. There is a max of 1,000
+				outbound SMS segments and MMS daily to T-Mobile (messages
+				exceeding this limit will fail).
+			</p><br /><h3>Private Company Third-Party Vetting</h3><p>
+				Private companies have the option to go with third-party
+				commercial vetting to improve their message throughput.
+			</p><h1>Campaign Information</h1><p>
+				You will need to provide information explaining to carriers how
+				your organization will be using SMS channels.
+			</p><p>
+				Our customers may register under the following standard use
+				cases.
+			</p><table>
+				<tbody
+					><tr><td> Use Case</td><td> Description</td></tr><tr
+						><td> Political</td><td
+							><p>
+								Part of an organized effort to influence the
+								decision-making of a specific group.
+							</p><p>All campaigns to be verified.</p></td
+						></tr
+					><tr
+						><td> Charity</td><td
+							>501(c)(3) organizations should register campaigns
+							with the Charity / 501(c)(3) special use case. Does
+							not include: Religious organizations.</td
+						></tr
+					><tr
+						><td> Emergency</td><td>
+							Notification services designed to support public
+							safety / health during natural disasters, armed
+							conflicts, pandemics and other national or regional
+							emergencies</td
+						></tr
+					><tr><td> Polling and voting</td><td><br /></td></tr><tr
+						><td> Public Service Announcement</td><td>
+							An informational message that is meant to raise the
+							audience&#39;s awareness about an important issue</td
+						></tr
+					></tbody
+				>
+			</table><h3>Charity Special Use Case</h3><p>
+				Verification of 501(c)(3) status is required.
+			</p><br /><h3>Political Special Use Case</h3><p>
+				A 10DLC campaign may be registered with the Political special
+				use case. Any candidate, party, PAC, or other committee that is
+				a 527 tax-exempt organization and registered with the Federal
+				Elections Commission (FEC) or a State, Local, or Tribal Election
+				Authority may be eligible for this special use case.
+			</p><p>
+				501(c)(4), 501(c)(5), and 501(c)(6) organizations sending
+				messages that are political in nature should also register with
+				the Political special use case.
+			</p>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-admins/user-roles.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/user-roles.astro
@@ -1,0 +1,566 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">User Roles</h2>
+
+			<h2>Types of&nbsp;Roles</h2><p>
+				Spoke has four roles, each with different levels of permissions.
+				You can access and edit these roles from the
+				<strong>People</strong>&nbsp;page of the administration <a
+					href="https://docs.spokerewired.com/article/52-dashboards"
+					target="_blank">dashboard</a
+				>.
+			</p><h3>Texter</h3>
+			<div>
+				A
+				<em> texter</em> is a member of your organization, often a volunteer,
+				who is able to text contacts in a campaign. Texters use the texter
+				<a
+					href="https://docs.spokerewired.com/article/52-dashboards"
+					target="_blank">dashboard</a
+				> to request conversation assignments and send messages.
+			</div><div>
+				Texters are responsible for sending initial messages and
+				responses to contacts, as well as answering survey questions as
+				the conversation progresses. Marking survey data is an essential
+				part of keeping a contact list up-to-date, and sets you up for
+				more tailored conversations in future texting campaigns.
+			</div><h3>Supervolunteer</h3><p>
+				A
+				<em>supervolunteer</em> has partial access to the administration
+				dashboard. They can help review and reassign conversations in Message
+				Review, as well as help approve requests from the Assignment Requests
+				page. Supervolunteer&nbsp;accounts have the same ability as texters
+				to request conversations and text contacts.
+			</p>
+			<div>
+				<h3>Admin</h3>
+				<p>
+					An
+					<em>administrator</em> (or <em>admin</em>) is a member of
+					your organization who can create, modify, and manage
+					campaigns and who has expanded access to
+					the&nbsp;administration dashboard. Administrator accounts
+					have the same ability as texters to request conversations
+					and text contacts.
+				</p>
+				<h3>Owner</h3>
+				<p>
+					An
+					<em>owner</em> has full access to the <a
+						href="https://docs.spokerewired.com/article/79-organizations"
+						target="_blank">organization</a
+					> and may manage organization settings, shortlink domains, and
+					bulk operations. They have full access to the administration
+					dashboard. Owner&nbsp;accounts have the same ability as texters
+					to request conversations and text contacts.
+				</p>
+			</div><h1>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/5f29ddf82c7d3a31c76a77f1/file-YIUqwvSGsz.gif"
+				/>Role Permissions
+			</h1>
+			<table>
+				<thead>
+					<tr>
+						<td> Action</td>
+						<td> Texter</td>
+						<td> Supervolunteer</td>
+						<td> Admin</td>
+						<td> Owner</td>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td>
+							<strong>Texting</strong>
+						</td>
+						<td> </td>
+						<td> </td>
+						<td> </td>
+						<td> </td>
+					</tr>
+					<tr>
+						<td> &nbsp; &nbsp; View Current Assignments</td>
+						<td> √</td>
+						<td> √</td>
+						<td> √</td>
+						<td> √</td>
+					</tr>
+					<tr>
+						<td> &nbsp; &nbsp; Request Assignment</td>
+						<td> √</td>
+						<td> √</td>
+						<td> √</td>
+						<td> √</td>
+					</tr>
+					<tr>
+						<td> &nbsp; &nbsp; Text on Assignment</td>
+						<td> √</td>
+						<td> √</td>
+						<td> √</td>
+						<td> √</td>
+					</tr>
+					<tr>
+						<td> &nbsp; &nbsp; Tag Conversation</td>
+						<td> √</td>
+						<td> √</td>
+						<td> √</td>
+						<td> √</td>
+					</tr>
+					<tr>
+						<td> &nbsp; &nbsp; Opt Contact Out</td>
+						<td> √</td>
+						<td> √</td>
+						<td> √</td>
+						<td> √</td>
+					</tr>
+					<tr>
+						<td>
+							<strong>Campaign Management</strong>
+						</td>
+						<td> </td>
+						<td> </td>
+						<td>
+							<br />
+						</td>
+						<td>
+							<br />
+						</td>
+					</tr>
+					<tr>
+						<td> &nbsp; &nbsp;&nbsp;View Campaign List</td>
+						<td><br /></td>
+						<td> √</td>
+						<td> √</td>
+						<td> √</td>
+					</tr>
+					<tr>
+						<td> &nbsp; &nbsp; Create/Copy Campaign</td>
+						<td><br /></td>
+						<td><br /></td>
+						<td> √</td>
+						<td> √</td>
+					</tr>
+					<tr>
+						<td> &nbsp; &nbsp; Archive/Unarchive Campaign</td>
+						<td><br /></td>
+						<td><br /></td>
+						<td> √</td>
+						<td> √</td>
+					</tr>
+					<tr>
+						<td>
+							&nbsp; &nbsp;&nbsp;Release Unsent Initials/Unhandled
+							Replies
+						</td>
+						<td><br /></td>
+						<td><br /></td>
+						<td> √</td>
+						<td> √</td>
+					</tr>
+					<tr>
+						<td>
+							&nbsp; &nbsp; Mark/Unmark Campaign for Second Pass
+						</td>
+						<td><br /></td>
+						<td><br /></td>
+						<td> √</td>
+						<td> √</td>
+					</tr>
+					<tr>
+						<td>
+							&nbsp; &nbsp; Delete Unmessaged Contacts from
+							Campaign
+						</td>
+						<td><br /></td>
+						<td><br /></td>
+						<td> √</td>
+						<td> √</td>
+					</tr>
+					<tr>
+						<td>
+							<strong>Campaign Building</strong>
+						</td>
+						<td> </td>
+						<td> </td>
+						<td> </td>
+						<td> </td>
+					</tr>
+					<tr>
+						<td> &nbsp; &nbsp; Edit Campaign</td>
+						<td><br /></td>
+						<td><br /></td>
+						<td> √</td>
+						<td> √</td>
+					</tr>
+					<tr>
+						<td> &nbsp; &nbsp; Export Campaign</td>
+						<td><br /></td>
+						<td><br /></td>
+						<td> √</td>
+						<td> √</td>
+					</tr>
+					<tr>
+						<td> &nbsp; &nbsp; View Script Preview</td>
+						<td><br /></td>
+						<td><br /></td>
+						<td> √</td>
+						<td> √</td>
+					</tr>
+					<tr>
+						<td> &nbsp; &nbsp; Start Campaign</td>
+						<td><br /></td>
+						<td><br /></td>
+						<td> √</td>
+						<td> √</td>
+					</tr>
+					<tr>
+						<td> &nbsp; &nbsp; Delete Stuck Job</td>
+						<td><br /></td>
+						<td><br /></td>
+						<td> √</td>
+						<td> √</td>
+					</tr>
+					<tr>
+						<td>
+							<strong>Manage People</strong>
+						</td>
+						<td> </td>
+						<td> </td>
+						<td> </td>
+						<td> </td>
+					</tr>
+					<tr>
+						<td> &nbsp; &nbsp; View People List</td>
+						<td><br /></td>
+						<td><br /></td>
+						<td> √</td>
+						<td> √</td>
+					</tr>
+					<tr>
+						<td> &nbsp; &nbsp; Change User Role</td>
+						<td><br /></td>
+						<td><br /></td>
+						<td> √</td>
+						<td> √</td>
+					</tr>
+					<tr>
+						<td> &nbsp; &nbsp; View Invite URL</td>
+						<td><br /></td>
+						<td><br /></td>
+						<td> √</td>
+						<td> √</td>
+					</tr>
+					<tr>
+						<td>
+							&nbsp; &nbsp; Edit User Profile (user can self-edit)
+						</td>
+						<td> √</td>
+						<td><br /></td>
+						<td><br /></td>
+						<td> √</td>
+					</tr>
+					<tr>
+						<td> &nbsp; &nbsp; Reset User Password</td>
+						<td><br /></td>
+						<td><br /></td>
+						<td> √</td>
+						<td> √</td>
+					</tr>
+					<tr>
+						<td>
+							<strong>Manage Teams</strong>
+						</td>
+						<td> </td>
+						<td> </td>
+						<td> </td>
+						<td> </td>
+					</tr>
+					<tr>
+						<td> &nbsp; &nbsp; View Teams</td>
+						<td><br /></td>
+						<td><br /></td>
+						<td> √</td>
+						<td> √</td>
+					</tr>
+					<tr>
+						<td> &nbsp; &nbsp; Create/Edit Team</td>
+						<td><br /></td>
+						<td><br /></td>
+						<td> √</td>
+						<td> √</td>
+					</tr>
+					<tr>
+						<td>
+							<strong>Auto-Assignment</strong>
+						</td>
+						<td> </td>
+						<td> </td>
+						<td> </td>
+						<td> </td>
+					</tr>
+					<tr>
+						<td> &nbsp; &nbsp; View Assignment Request Control</td>
+						<td><br /></td>
+						<td><br /></td>
+						<td> √</td>
+						<td> √</td>
+					</tr>
+					<tr>
+						<td> &nbsp; &nbsp; Edit Assignment Request Controls</td>
+						<td><br /></td>
+						<td><br /></td>
+						<td> √</td>
+						<td> √</td>
+					</tr>
+					<tr>
+						<td> &nbsp; &nbsp; View Assignment Requests</td>
+						<td><br /></td>
+						<td> √</td>
+						<td> √</td>
+						<td> √</td>
+					</tr>
+					<tr>
+						<td> &nbsp; &nbsp; Approve/Deny Assignment Requests</td>
+						<td><br /></td>
+						<td> √</td>
+						<td> √</td>
+						<td> √</td>
+					</tr>
+					<tr>
+						<td>
+							<strong>Manage Tags</strong>
+						</td>
+						<td> </td>
+						<td> </td>
+						<td> </td>
+						<td> </td>
+					</tr>
+					<tr>
+						<td> &nbsp; &nbsp; View Contact's Tags</td>
+						<td> √</td>
+						<td> √</td>
+						<td> √</td>
+						<td> √</td>
+					</tr>
+					<tr>
+						<td> &nbsp; &nbsp; View All Tags</td>
+						<td><br /></td>
+						<td><br /></td>
+						<td> √</td>
+						<td> √</td>
+					</tr>
+					<tr>
+						<td> &nbsp; &nbsp; Create/Edit Tag</td>
+						<td><br /></td>
+						<td><br /></td>
+						<td> √</td>
+						<td> √</td>
+					</tr>
+					<tr>
+						<td>
+							<strong
+								>Message Review / Escalated Conversations</strong
+							>
+						</td>
+						<td> </td>
+						<td> </td>
+						<td> </td>
+						<td> </td>
+					</tr>
+					<tr>
+						<td> &nbsp; &nbsp; View/Filter Conversations</td>
+						<td><br /></td>
+						<td> √</td>
+						<td> √</td>
+						<td> √</td>
+					</tr>
+					<tr>
+						<td>
+							&nbsp; &nbsp; Reassign/Unassign Conversations
+							<br />
+						</td>
+						<td><br /></td>
+						<td><br /></td>
+						<td> √</td>
+						<td> √</td>
+					</tr>
+					<tr>
+						<td> &nbsp; &nbsp; Text on Conversation</td>
+						<td><br /></td>
+						<td> √</td>
+						<td> √</td>
+						<td> √</td>
+					</tr>
+					<tr>
+						<td>
+							&nbsp; &nbsp;&nbsp;Update Survey Response
+							<br />
+						</td>
+						<td><br /></td>
+						<td> √</td>
+						<td> √</td>
+						<td> √</td>
+					</tr>
+					<tr>
+						<td> &nbsp; &nbsp; Manage Conversation Tags</td>
+						<td><br /></td>
+						<td> √</td>
+						<td> √</td>
+						<td>
+							√
+							<br />
+						</td>
+					</tr>
+					<tr>
+						<td>
+							&nbsp; &nbsp; View/Filter Escalated Conversations
+						</td>
+						<td><br /></td>
+						<td><br /></td>
+						<td> √</td>
+						<td> √</td>
+					</tr>
+					<tr>
+						<td>
+							<strong>TrollBot</strong>
+						</td>
+						<td> </td>
+						<td> </td>
+						<td> </td>
+						<td> </td>
+					</tr>
+					<tr>
+						<td> &nbsp; &nbsp; Manage Tokens</td>
+						<td><br /></td>
+						<td> √</td>
+						<td> √</td>
+						<td> √</td>
+					</tr>
+					<tr>
+						<td> &nbsp; &nbsp; Manage Alarms</td>
+						<td><br /></td>
+						<td> √</td>
+						<td> √</td>
+						<td> √</td>
+					</tr>
+					<tr>
+						<td>
+							<strong>Bulk Script Editor</strong>
+						</td>
+						<td>
+							<br />
+						</td>
+						<td>
+							<br />
+						</td>
+						<td> </td>
+						<td> </td>
+					</tr>
+					<tr>
+						<td> &nbsp; &nbsp; Bulk Update Scripts</td>
+						<td><br /></td>
+						<td><br /></td>
+						<td><br /></td>
+						<td> √</td>
+					</tr>
+					<tr>
+						<td>
+							<strong>Manage Short Link Domains</strong>
+						</td>
+						<td> </td>
+						<td> </td>
+						<td> </td>
+						<td> </td>
+					</tr>
+					<tr>
+						<td> &nbsp; &nbsp; View All Short Link Domains</td>
+						<td> √</td>
+						<td><br /></td>
+						<td> √</td>
+						<td> √</td>
+					</tr>
+					<tr>
+						<td> &nbsp; &nbsp; Create/Edit Short Link Domain</td>
+						<td><br /></td>
+						<td><br /></td>
+						<td><br /></td>
+						<td> √</td>
+					</tr>
+					<tr>
+						<td>
+							<strong>Manage Organization Settings</strong>
+						</td>
+						<td>
+							<br />
+						</td>
+						<td> </td>
+						<td> </td>
+						<td> </td>
+					</tr>
+					<tr>
+						<td> &nbsp; &nbsp; View Organization Settings</td>
+						<td><br /></td>
+						<td><br /></td>
+						<td><br /></td>
+						<td> √</td>
+					</tr>
+					<tr>
+						<td> &nbsp; &nbsp; Edit Organization Settings</td>
+						<td><br /></td>
+						<td><br /></td>
+						<td><br /></td>
+						<td> √</td>
+					</tr>
+					<tr>
+						<td> &nbsp; &nbsp; View Organization's Opt Outs</td>
+						<td><br /></td>
+						<td><br /></td>
+						<td> √</td>
+						<td> √</td>
+					</tr>
+					<tr>
+						<td>
+							<strong>Integrations</strong>
+						</td>
+						<td> </td>
+						<td> </td>
+						<td> </td>
+						<td> </td>
+					</tr>
+					<tr>
+						<td> &nbsp; &nbsp; Manage integrations</td>
+						<td><br /></td>
+						<td><br /></td>
+						<td><br /></td>
+						<td> √</td>
+					</tr>
+					<tr>
+						<td>
+							&nbsp; &nbsp; Load contact list from integration
+						</td>
+						<td><br /></td>
+						<td><br /></td>
+						<td> √</td>
+						<td> √</td>
+					</tr>
+					<tr>
+						<td> </td>
+						<td> </td>
+						<td> </td>
+						<td> </td>
+						<td> </td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-admins/van-list-loading.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/van-list-loading.astro
@@ -1,0 +1,292 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">Van List Loading</h2>
+
+			<h2>Setting up your VAN integration&nbsp;</h2><p>
+				Using the version (or
+				<em>fork</em>) of Spoke specific to Politics Rewired, you are
+				able to load <strong>saved lists</strong><strong>
+					from VAN</strong
+				> directly into texting campaigns. This is done through a <a
+					href="https://help.ngpvan.com/van/s/article/2969508-requesting-and-approving-api-keys"
+					>VAN integration</a
+				>.
+			</p><h2>Set up VAN for Spoke integration</h2><p>
+				1. You will need the application name and API key from
+				VAN.&nbsp;
+			</p><p style="margin-left: 40px;">
+				<b style="background-color: initial;">Accepted:</b> Politics Rewired-,
+				Hustle-, or Civis-type VAN API keys.
+			</p><p style="margin-left: 40px;">
+				<b style="background-color: initial;">Not Accepted:</b> Spoke- type
+				VAN API keys.
+			</p><ul>
+				<li>
+					<strong>Application name</strong> -- This will be the "username"
+					for the Spoke integration. It will be of the form: DNCNY.000.hustle
+				</li>
+				<li>
+					<strong>API Key</strong> -- This&nbsp;will be of the form:&nbsp;b1b9de3b-12b1-4e13-bebe-115123aa6536
+				</li>
+			</ul><p>
+				2. Be sure that you've saved a
+				<strong>LIST</strong>rather than a <strong>QUERY</strong>. Saved
+				searches can't be pulled into Spoke, but saved lists can be!
+			</p>
+			<div>
+				3. The list in VAN must be in a folder shared with the API key
+				user. Follow the steps below to allow this access:&nbsp;
+			</div><ol>
+				<li>
+					In VAN, go to the folder that contains the lists you want to
+					show up in Spoke
+				</li>
+				<li>In the top right corner, click "Edit Folder"</li>
+				<li>Turn on "Allow other user to save into this folder"</li>
+				<li>Turn on "Allow the API to save into this folder"</li>
+				<li>
+					Go down to the "User Access" section and add the API user
+					into the "Users with Access" column
+				</li>
+				<li>Press save</li>
+			</ol><h2>Create VAN integration in Spoke</h2><p>
+				1. First, navigate to
+				<em>Integrations&nbsp;</em>on your left-side admin panel.
+			</p><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/5ee9247b2c7d3a10cba90472/file-XxYzNfOZT2.png"
+					style="background-color: initial; width: 143px; margin: auto;"
+					alt=""
+				/>
+			</p><p>
+				2. Click on the "+" symbol in the bottom right corner of your
+				screen.&nbsp;
+			</p><p>3. Create and save the integration:</p><ul>
+				<li>
+					<strong>Integration name</strong> -- You can name your integration
+					whatever you'd like! <em>Archie</em>&nbsp;has a nice ring.
+				</li>
+				<li>
+					<strong>System type</strong> -- This should be "Votebuilder."
+				</li>
+				<li>
+					<strong>Van operation mode</strong> -- Select "Voterfile" if
+					you will be pulling voter lists and select "MyCampaign" if you
+					would like to pull lists on volunteers you load into VAN. If
+					you are not sure what to select, select "Voterfile."
+				</li>
+				<li>
+					<strong>Username</strong> -- This is your "Application name"
+					from VAN. If it ends in <em>spoke</em>, refer to the section
+					above as this is (counterintuitively) invalid!
+				</li>
+				<li>
+					<strong>API key</strong> -- This is your "API key" from VAN.
+				</li>
+			</ul><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/62a1ff6857320007925231e6/file-8aK9syO5SL.png"
+					style="width: 260px;"
+				/>
+			</p><h2>Pull list information</h2><p>
+				You will need to pull list information from VAN before you can
+				select a list to load into a campaign.
+			</p><p>
+				1. Click
+				<em>Sync&nbsp;</em>on the Integration page.
+			</p><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/63238369b0f178684ee3b1d8/file-Kf88HxQIKm.png"
+				/>
+			</p><p>
+				2. Refresh the integrations list. The&nbsp;
+				<em>sync options last fetched&nbsp;</em>column will update when
+				the list information has been pulled.
+			</p><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/632383a4b0f178684ee3b1dc/file-y1nEkObCD6.jpg"
+				/>
+			</p><p>
+				Please note, our configure opt outs feature is under
+				construction. Please email us if you'd like to configure how
+				opt-outs appear in your VAN.&nbsp;
+			</p><h2>Load a list</h2><p>
+				1. Click into the
+				<em>Integration</em>&nbsp;drop-down menu in the Campaign Edit
+				page and link your new campaign to your VAN Integration then
+				click SAVE.
+			</p><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/5f7654bb52faff0016aebda4/file-6IND6pTRa7.png"
+				/>
+			</p><p>
+				2. Then click into the
+				<em>Contacts</em> drop-down menu. Update the <em
+					>Contact source</em
+				> to <em>Integration&nbsp;</em>(replacing&nbsp;<em
+					style="background-color: initial;">CSV</em
+				>)<i style="background-color: initial;">&nbsp;</i>and choose
+				which saved list from VAN that you would like to
+				text.&nbsp;Click Save to begin importing the list's contacts
+				into Spoke.
+			</p><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/5f76561dc9e77c0016213b21/file-gW82xMKCqF.png"
+				/>
+			</p><h2>Write script with VAN-provided fields</h2><p>
+				VAN provides a large assortment of custom fields to use in
+				scripts. Depending on your VAN committee, however, many of these
+				may not have values. You should check with your VAN
+				administrator about which fields are guaranteed to contain
+				values.
+			</p><h2>Sync data back to VAN</h2><p>
+				1. Click the&nbsp;
+				<em>Sync To VAN</em>button&nbsp;on the top right corner of the
+				Individual Campaign Page.
+			</p><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/5f765ccb46e0fb0017988f3b/file-LF5Am59eAF.png"
+				/>
+			</p><p>
+				2. Then click
+				<em>Configure Mapping</em> on the Sync to VAN pop-up menu.
+			</p><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/5f765ce4cff47e001a58a5c2/file-LdAIB5OJZI.png"
+				/>
+			</p><p>
+				3. All of your survey answers will be displayed on the Configure
+				Mapping pop-up. Survey answers that have currently been selected
+				by your texters will be tagged with the yellow triangle. Survey
+				answers that have not been used yet in conversations will be
+				tagged with a gray circle.
+			</p><p>
+				To start linking your survey options back to VAN click the plus
+				sign to the right of the survey answer.
+			</p><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/5f765cf8cff47e001a58a5c3/file-RQfWXu399I.png"
+				/>
+			</p><p>
+				4. Select between VAN&nbsp;
+				<em>Survey Response, Activist Code</em> and <em>Result Code</em>
+				in the <em>Mapping Type</em> drop-down menu. Once you have finished
+				selecting your VAN pathway, click <em>ADD</em>.
+			</p><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/5f765d2046e0fb0017988f3c/file-ednffR3Gos.png"
+				/>
+			</p><p>
+				5. After you have linked all of your survey answers back to VAN,
+				click
+				<em>OK</em>.
+			</p><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/5f765d4752faff0016aebdc0/file-oDRbwQ4B6K.png"
+				/>
+			</p><p>
+				8. Finish the process by clicking
+				<em>Sync</em>!
+			</p><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/5f765d60c9e77c0016213b37/file-q7aiEXr51e.png"
+				/>
+			</p><h1></h1><h1>Troubleshooting your VAN integration</h1><h4>
+				<strong><br /></strong>
+			</h4><h4></h4><h4>
+				After setting up the integration, the contact list won't upload
+				beyond 0%.
+			</h4><p>
+				<strong>Solution:</strong> Refresh sync.&nbsp;
+			</p><p>
+				1. Click&nbsp;
+				<em>Refresh Sync Options</em>&nbsp;on the Integration page.
+			</p><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/5f765bd946e0fb0017988f39/file-dk94bikYch.png"
+				/>
+			</p><p>
+				2. Refresh the integrations list. The&nbsp;
+				<em>last synced&nbsp;</em>column will update when the list
+				information has been pulled.
+			</p><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/5f765c7dcff47e001a58a5c1/file-EXQ3WL2nxm.png"
+				/>
+			</p><h4><strong><br /></strong></h4><h4>
+				<strong>Lists in VAN will not show up in Spoke.</strong>
+			</h4><p>
+				<strong>Solution:&nbsp;</strong>Share VAN folders with the API
+				key user.
+			</p><ol>
+				<li>
+					In VAN, go to the folder that contains the lists you want to
+					show up in Spoke
+				</li>
+				<li>In the top right corner, click "Edit Folder"</li>
+				<li>Turn on "Allow other user to save into this folder"</li>
+				<li>Turn on "Allow the API to save into this folder"</li>
+				<li>
+					Go down to the "User Access" section and add the API user
+					into the "Users with Access" column
+				</li>
+				<li>Press save</li>
+				<li>
+					In Spoke, go to the "Integrations" menu item on the left
+					menu of your administrative dashboard
+				</li>
+				<li>
+					On the right side of the API integration you have set up,
+					press "Sync Refresh"
+				</li>
+				<li>
+					Above that and on the middle of the screen, press "Refresh"
+				</li>
+			</ol><p>
+				After completing those steps and selecting the API integration
+				in the "Integration" section in the campaign, you will have
+				access to the new lists in the "Contact" section.
+			</p><p>
+				If there are still issues, this is what else you can try:
+			</p><ul>
+				<li>
+					Check to confirm the username and API key are in the correct
+					format
+				</li>
+				<li>Try both modes of VAN integration</li><li>
+					Do a hard refresh of the campaign page after any changes
+				</li>
+			</ul><h4><strong><br /></strong></h4><h4>
+				<strong>No options show up when configuring the mapping.</strong
+				>
+			</h4><p>
+				<strong>Solution:</strong>&nbsp;Create questions and survey
+				responses in the script.
+			</p><ol>
+				<li>
+					Go to interactions and under the initial text, write a
+					question
+				</li>
+				<li>
+					Provide responses to the question by clicking&nbsp;<strong
+						>Add a Response</strong
+					>
+				</li>
+			</ol><p>
+				Learn more about
+				<a
+					href="https://docs.spokerewired.com/article/43-create-interaction-script"
+					>writing responses to surveys here</a
+				>.
+			</p>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-admins/writing-scripts.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/writing-scripts.astro
@@ -1,0 +1,232 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">Writing Scripts</h2>
+
+			<p>
+				Your texting scripts should be clear, concise, and
+				conversational. Generally speaking, you should aim to present
+				all the information your contacts need to know in as few words
+				as possible, while still using language that sounds natural.
+				Your scripts should sound like they're coming from real people –
+				because they are! You should always
+				<strong>include opt out language</strong> like <strong
+					>stop=quit</strong
+				> and if you're sending a link, please consult our article on <a
+					href="https://docs.spokerewired.com/article/70-short-link-domains"
+					>short links</a
+				> to ensure deliverability.&nbsp;
+			</p><h2>Initial Messages</h2><p>
+				Initial messages typically follow a three-part structure:
+				introduction, argument, and ask.
+			</p><h4>Introduction</h4><p>
+				The introduction is where you introduce both your organization
+				and the individual texter to the contact. If you're texting for
+				an electoral campaign, this is also where you would introduce
+				the candidate, as well as the officer they're running for. Here
+				are a couple of examples:
+			</p><p>
+				<em
+					>"Hi {firstName}, it's {texterFirstName} with the Rebel Alliance."</em
+				>
+			</p><p>
+				<em
+					>"Hi {firstName}! My name is {texterFirstName} and I'm a volunteer
+					with Baby Yoda, who is running for Co</em
+				><em>ruscant</em><i style="background-color: initial;"
+					>&nbsp;City Council."</i
+				>
+			</p><p>
+				For
+				<strong>second pass</strong> initial messages, you can leave out
+				introducing the texter and your organization, since the message will
+				appear immediate below the first pass in their thread, which already
+				contains that information. Here are some examples second pass introductions:
+			</p><p>
+				<em
+					>"Hi {firstName}, just wanted to make sure you saw our first
+					message!"</em
+				>
+			</p><p>
+				<em
+					>"Hi {firstName}! Just checking in again to see if you
+					can...</em
+				>
+			</p><h4>Argument&nbsp;</h4><p>
+				The argument is where you make the case for why the contact
+				should do the thing you're asking them to do. If you're inviting
+				them to an event, you'll want to describe it in way that feels
+				compelling and urgent. If you're asking them to support a
+				candidate, you'll want to give an elevator pitch about what
+				their campaign is all about, lifting up their core message
+				and/or issues. Here are some example arguments, building off our
+				introductions:
+			</p><p>
+				<em
+					>"Hi {firstName}, it's {texterFirstName} with the Rebel Alliance.
+					For decades, Imperial bankers and traders have made billions
+					of credits, while ordinary workers have struggled to make ends
+					meet. That's why we're organizing a galactic livestream on wealth
+					and income inequality and what you can do to fight back this
+					Friday, March 26th at 8pm CT."</em
+				>
+			</p><p>
+				<em
+					>"Hi {firstName}! My name is {texterFirstName} and I'm a volunteer
+					with Baby Yoda, who is running for Co</em
+				><em>ruscant</em><em
+					>&nbsp;City Council. Baby Yoda has spent his entire career
+					standing up to the Imperial elite and fighting for ordinary
+					working people across the galaxy. He's running to make
+					health care, housing, and education rights to all people, no
+					matter what star system you're from."</em
+				>
+			</p><h4>Ask</h4><p>
+				The ask is where you present a clear question to the contact.
+				Your ask should correspond with the survey question in your
+				Interactions script. Here are some example asks, building off
+				our arguments:
+			</p><p>
+				<em
+					>"Hi {firstName}, it's {texterFirstName} with the Rebel Alliance.
+					For decades, Imperial bankers and traders have made billions,
+					while ordinary workers have struggled to make ends meet. That's
+					why we're organizing a galactic livestream on wealth and income
+					inequality and what you can do to fight back this Friday, March
+					26th at 8pm CT. Can you join us?"</em
+				>
+			</p><p>
+				<em
+					>"Hi {firstName}! My name is {texterFirstName} and I'm a volunteer
+					with Baby Yoda, who is running for Co</em
+				><em>ruscant</em><em
+					>&nbsp;City Council. Baby Yoda has spent his entire career
+					standing up to the Imperial elite and fighting for ordinary
+					working people across the galaxy. He's running to make
+					health care, housing, and education rights to all people, no
+					matter what star system you're from. Can Baby Yoda count on
+					your vote this November?"</em
+				>
+			</p><p>Here are some other common ways of making a clear ask:</p><p>
+				<em>"Can you make it?"<br /></em><i
+					style="background-color: initial;"
+					>"Can you be there?"<br />
+					"Can we count on your support?"
+					<br />
+				</i><i style="background-color: initial;"
+					>"Will you volunteer?"</i
+				>
+			</p><h3>Survey Response Scripts</h3><p>
+				Your survey response scripts should clearly and succinctly
+				convey the information the contact needs, based on how they
+				responded to the ask in your initial message. Response
+				scripts&nbsp;should be written so that, in most cases, they can
+				be sent with little to no editing. However, they should also be
+				flexible enough so that they're easy to personalize when
+				appropriate.
+			</p><p>
+				The survey scripts you create will depend on what your ask is
+				and what kind of data you want to collect. Two of the most
+				common script structures are a Yes/No/Maybe script and a Voter
+				ID script.
+			</p><h4>Yes/No/Maybe Script</h4><p>
+				This is the script structure you'll use for any ask that's posed
+				as a Yes/No question, such as an event recruitment or volunteer
+				recruitment campaign. He's an example:
+			</p><p>
+				<strong>YES they will attend the event</strong><br />
+				<em
+					>"Great! To join the virtual event, please register here: <a
+						href="http://www.notarealwebsite.com"
+						>www.notarealwebsite.com</a
+					> You'll then get emailed a link to join the livestream. Looking
+					forward to it!"</em
+				>
+			</p><p>
+				<strong>NO they will not attend the event</strong><br />
+				<em>"I understand, thanks for letting me know!"</em>
+			</p><p>
+				<strong>MAYBE they will attend the event</strong><br />
+				<strong></strong><em>"OK! If you're able to make it,&nbsp;</em
+				><em style="background-color: initial;"
+					>please register here: <a
+						href="http://www.notarealwebsite.com/"
+						>www.notarealwebsite.com</a
+					> You'll then get emailed a link to join the livestream. Hope
+					you can make it!"</em
+				>
+			</p><h4>Vote ID Scripts</h4><p>
+				This is the script you'll use when trying to asses voters' level
+				of support for a candidate, or possibly, their level of support
+				for an issue, ballot measure, or union. Typically, voter ID
+				scripts use a 1-5 scale to measure support. Here's an example:
+			</p><p>
+				<strong
+					>1 - They will DEFINITELY support the candidate&nbsp;</strong
+				><br />
+				<em>"</em><em
+					>Amazing! Thanks so much for your support. It's going to
+					take all of us to win this election. Will you volunteer with
+					our people-powered campaign?"</em
+				>
+			</p><p>
+				<strong
+					>2 - They will LIKELY support the candidate&nbsp;<br />
+				</strong><em
+					>"That's great to hear! It's going to take all of us to win
+					this election. Will you volunteer with our people-powered
+					campaign?"</em
+				>
+			</p><p>
+				<strong>3 - They MAYBE will support the candidate</strong><br />
+				"
+				<em
+					>OK! Please let me know if you have any questions I can
+					answer. Have a good day!"</em
+				>
+			</p><p>
+				<strong
+					>4 - They will LIKELY NOT support the candidate<br />
+				</strong><em
+					>"I understand, thanks for letting me know. Take good care!"</em
+				>
+			</p><p>
+				<strong
+					>5 - They will DEFINITELY NOT support the candidate</strong
+				><br />
+				<em>"I understand. Have a good rest of your day!"</em>
+			</p><h4>Generic Survey Scripts</h4><p>
+				In addition to the survey scripts that are designed to respond
+				to replies to your initial message, you'll also want to include
+				some generic scripts for common replies that don't have anything
+				to do with your specific ask. Typically, these generic survey
+				scripts can be applied across all&nbsp;of your campaigns,
+				sometimes with slight variations. Here are some examples:
+			</p><p>
+				<strong>Wrong Number</strong><br />
+				<em>"</em><em
+					>Sorry about that! I've just made a note to update our
+					records. Take good care!"</em
+				>
+			</p><p>
+				<strong>Refused/Angry</strong><br />
+				<em>"</em><em>I understand. Have a good rest of your day!"</em>
+			</p><p>
+				<strong>Moved</strong><br />
+				<em>"</em><em>Got it, thanks for letting me know!"</em>
+			</p><hr /><p>
+				Ultimately, there are as many possible scripts as there are
+				campaigns! If you'd like support crafting a campaign script,
+				please reach out at
+				<strong>support@spokerewired.com</strong>
+			</p>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-admins/writing-scripts.astro
+++ b/src/pages/docs/spoke/for-spoke-admins/writing-scripts.astro
@@ -34,12 +34,14 @@ import "animate.css";
 				are a couple of examples:
 			</p><p>
 				<em
-					>"Hi {firstName}, it's {texterFirstName} with the Rebel Alliance."</em
+					>"Hi &lcub;firstName&rcub;, it's &lcub;texterFirstName&rcub;
+					with the Rebel Alliance."</em
 				>
 			</p><p>
 				<em
-					>"Hi {firstName}! My name is {texterFirstName} and I'm a volunteer
-					with Baby Yoda, who is running for Co</em
+					>"Hi &lcub;firstName&rcub;! My name is
+					&lcub;texterFirstName&rcub; and I'm a volunteer with Baby
+					Yoda, who is running for Co</em
 				><em>ruscant</em><i style="background-color: initial;"
 					>&nbsp;City Council."</i
 				>
@@ -51,13 +53,13 @@ import "animate.css";
 				contains that information. Here are some examples second pass introductions:
 			</p><p>
 				<em
-					>"Hi {firstName}, just wanted to make sure you saw our first
-					message!"</em
+					>"Hi &lcub;firstName&rcub;, just wanted to make sure you saw
+					our first message!"</em
 				>
 			</p><p>
 				<em
-					>"Hi {firstName}! Just checking in again to see if you
-					can...</em
+					>"Hi &lcub;firstName&rcub;! Just checking in again to see if
+					you can...</em
 				>
 			</p><h4>Argument&nbsp;</h4><p>
 				The argument is where you make the case for why the contact
@@ -70,17 +72,19 @@ import "animate.css";
 				introductions:
 			</p><p>
 				<em
-					>"Hi {firstName}, it's {texterFirstName} with the Rebel Alliance.
-					For decades, Imperial bankers and traders have made billions
-					of credits, while ordinary workers have struggled to make ends
-					meet. That's why we're organizing a galactic livestream on wealth
-					and income inequality and what you can do to fight back this
-					Friday, March 26th at 8pm CT."</em
+					>"Hi &lcub;firstName&rcub;, it's &lcub;texterFirstName&rcub;
+					with the Rebel Alliance. For decades, Imperial bankers and
+					traders have made billions of credits, while ordinary
+					workers have struggled to make ends meet. That's why we're
+					organizing a galactic livestream on wealth and income
+					inequality and what you can do to fight back this Friday,
+					March 26th at 8pm CT."</em
 				>
 			</p><p>
 				<em
-					>"Hi {firstName}! My name is {texterFirstName} and I'm a volunteer
-					with Baby Yoda, who is running for Co</em
+					>"Hi &lcub;firstName&rcub;! My name is
+					&lcub;texterFirstName&rcub; and I'm a volunteer with Baby
+					Yoda, who is running for Co</em
 				><em>ruscant</em><em
 					>&nbsp;City Council. Baby Yoda has spent his entire career
 					standing up to the Imperial elite and fighting for ordinary
@@ -95,17 +99,19 @@ import "animate.css";
 				our arguments:
 			</p><p>
 				<em
-					>"Hi {firstName}, it's {texterFirstName} with the Rebel Alliance.
-					For decades, Imperial bankers and traders have made billions,
-					while ordinary workers have struggled to make ends meet. That's
-					why we're organizing a galactic livestream on wealth and income
-					inequality and what you can do to fight back this Friday, March
-					26th at 8pm CT. Can you join us?"</em
+					>"Hi &lcub;firstName&rcub;, it's &lcub;texterFirstName&rcub;
+					with the Rebel Alliance. For decades, Imperial bankers and
+					traders have made billions, while ordinary workers have
+					struggled to make ends meet. That's why we're organizing a
+					galactic livestream on wealth and income inequality and what
+					you can do to fight back this Friday, March 26th at 8pm CT.
+					Can you join us?"</em
 				>
 			</p><p>
 				<em
-					>"Hi {firstName}! My name is {texterFirstName} and I'm a volunteer
-					with Baby Yoda, who is running for Co</em
+					>"Hi &lcub;firstName&rcub;! My name is
+					&lcub;texterFirstName&rcub; and I'm a volunteer with Baby
+					Yoda, who is running for Co</em
 				><em>ruscant</em><em
 					>&nbsp;City Council. Baby Yoda has spent his entire career
 					standing up to the Imperial elite and fighting for ordinary

--- a/src/pages/docs/spoke/for-spoke-texters/add-tags-to-a-conversation.astro
+++ b/src/pages/docs/spoke/for-spoke-texters/add-tags-to-a-conversation.astro
@@ -1,0 +1,50 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">Add Tags To A Conversation</h2>
+
+			<p>
+				Adding tags to a conversation allows your Spoke administrators
+				to keep informed about your contacts. For example, you can use
+				tags to indicate your contact's primary language, or you can use
+				tags to
+				<a
+					href="https://docs.spokerewired.com/article/81-escalate-a-conversation"
+					data-bcup-haslogintext="no">escalate a conversation</a
+				>. For information on how you should be using tags, contact your
+				Spoke administrators.
+			</p><h5><em>To add a tag to a conversation:</em></h5><ol>
+				<li>
+					From an open conversation, click <strong>Manage Tags</strong
+					>.
+				</li>
+				<li>
+					Click the <strong>Select...&nbsp;</strong>box underneath
+					"Apply tags"
+				</li>
+				<li>
+					Choose one or more tags from the list, or start typing to
+					search for a specific tag.&nbsp;
+				</li>
+				<li>
+					Once the desired tag(s) have been selected, click <strong
+						>Save.</strong
+					>
+				</li>
+			</ol><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/60010656c64fe14d0e1fb2f4/file-xVgIY7fQTF.png"
+					alt=""
+					style="display: block; margin: auto;"
+				/>
+			</p>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-texters/close-conversation.astro
+++ b/src/pages/docs/spoke/for-spoke-texters/close-conversation.astro
@@ -1,0 +1,41 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">Close Conversation</h2>
+
+			<p>
+				Closing a reply allows you to move onto the next conversation
+				without sending a reply to a contact. You can return to
+				conversations that you skipped using the <strong
+					>Skipped Messages</strong
+				> button on the texter dashboard.
+			</p><h5><em> To close a reply:</em></h5><ul>
+				<li>
+					From a conversation, click <strong
+						style="background-color: initial;">Close</strong
+					>, as shown here:
+
+					<p>
+						<img
+							src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/62f4192f80fd5a31e7ad1112/file-hVwqa6Ywu9.png"
+						/>
+					</p>
+				</li>
+			</ul><blockquote>
+				<strong>Note:</strong> if you want to temporarily skip a conversation
+				and immediately come back to it, it may be easier to click the&nbsp;
+				<strong>"NEXT &gt;"</strong>button on the far right side of your
+				control panel, rather than Close. This will simply place the
+				conversation at the end of your existing workflow, instead of
+				moving it to the Skipped Messages category.&nbsp;
+			</blockquote>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-texters/escalate-a-conversation.astro
+++ b/src/pages/docs/spoke/for-spoke-texters/escalate-a-conversation.astro
@@ -1,0 +1,41 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">Escalate A Conversation</h2>
+
+			<p>
+				Escalating a conversation brings it to the attention of your
+				Spoke administrators, allowing them to take appropriate action.
+				Typically, you should first ask the person running your texting
+				program if it's appropriate to escalate a given kind of
+				conversation.
+			</p><h5><em>To escalate a conversation:<br /></em></h5><ol>
+				<li>
+					From an active conversation, click <strong
+						>Manage Tags</strong
+					>.
+				</li>
+				<li>Click <strong>Escalate Conversation</strong>.</li>
+				<li>
+					Click <strong>Save and type message</strong>or <strong
+						>Save and move on without a message.&nbsp;</strong
+					>
+				</li>
+			</ol><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/62f4181e829a3853b692588f/file-jA2p8rLEnA.png"
+				/>
+			</p><blockquote>
+				Note: In most cases, saving and moving on without a message will
+				be most appropriate.
+			</blockquote>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-texters/index.astro
+++ b/src/pages/docs/spoke/for-spoke-texters/index.astro
@@ -1,0 +1,16 @@
+---
+import SpokeDocsList from "../../../../components/DocsCollection/SpokeDocsList.astro";
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+    <main
+        class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+    >
+        <h2 class="text-center">For Spoke Texters</h2>
+        <div class="flex items-center flex-col">
+            <SpokeDocsList collectionType="for-spoke-texters" />
+        </div>
+    </main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-texters/opt-out-a-contact.astro
+++ b/src/pages/docs/spoke/for-spoke-texters/opt-out-a-contact.astro
@@ -1,0 +1,66 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">Opt Out A Contact</h2>
+
+			<p>
+				Opting out a contact adds them to your organization's opt-out
+				list. This prevents you from sending more messages to the
+				contact. All future campaigns automatically remove contacts who
+				are on the opt-out list.&nbsp;
+			</p><blockquote>
+				Note: Opt-outs are permanent. Please make sure to ask your
+				administrator about which conversations you should opt out and
+				which you should not.
+			</blockquote><h2>Opt Out with a Message</h2><p>
+				Opting out with a message allows you to confirm with the contact
+				that you're opting them out of future text communications with
+				your organization.
+			</p><h5>
+				<em>To opt-out a contact with a follow-up message:</em>
+			</h5><ol>
+				<li>
+					While in a conversation, click <strong>Opt Out</strong>.
+				</li>
+				<li>
+					Read the auto-generated prepared response. Edit if needed.
+				</li>
+				<li>
+					Click <strong style="background-color: initial;"
+						>Send</strong
+					>.
+				</li>
+			</ol><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/60010465b9a8501b295d0bde/file-h6TMtPBGp5.png"
+					alt=""
+					style="display: block; margin: auto;"
+				/>
+			</p><h2>Opt Out without a Message</h2><p>
+				Opting out a contact without a message prevents you from
+				disturbing them further.
+			</p><h5>
+				<em>To opt-out a contact without a followup message:</em>
+			</h5><ol>
+				<li>
+					While in a conversation, click <strong>Opt-out</strong>.
+				</li>
+				<li>Delete the auto-generated prepared response</li>
+				<li>Click <strong>Opt Out Without Text</strong>.</li>
+			</ol><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/6001043db9a8501b295d0bdb/file-DlM50hjDV4.png"
+					alt=""
+					style="display: block; margin: auto;"
+				/>
+			</p>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-texters/request-texts.astro
+++ b/src/pages/docs/spoke/for-spoke-texters/request-texts.astro
@@ -31,7 +31,7 @@ import "animate.css";
 					a message will be displayed.
 				</li>
 				<li>Click <strong>Request More Texts</strong>.</li>
-			</ol><p align="Center">
+			</ol><p style="text-align: center;">
 				<img
 					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/5f6ba3cb52faff00174f2896/file-lPs3SGl21v.png"
 				/>

--- a/src/pages/docs/spoke/for-spoke-texters/request-texts.astro
+++ b/src/pages/docs/spoke/for-spoke-texters/request-texts.astro
@@ -1,0 +1,41 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">Request Texts</h2>
+
+			<p>
+				If you are a
+				<a
+					href="https://docs.spokerewired.com/article/6-user-roles"
+					target="_blank">texter</a
+				>, you can request a texting assignment to start having
+				conversations with contacts. These could be volunteers,
+				supporters, voters – it depends on the campaign!
+			</p><h5><em>To request a texting assignment:</em></h5><ol>
+				<li>
+					Open the texter <a
+						href="https://docs.spokerewired.com/article/52-dashboards"
+						>dashboard</a
+					>.
+				</li>
+				<li>
+					In the <strong>Count</strong> field, specify the number of conversations
+					you want to be assigned to you. If there are no unassigned conversations,
+					a message will be displayed.
+				</li>
+				<li>Click <strong>Request More Texts</strong>.</li>
+			</ol><p align="Center">
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/5f6ba3cb52faff00174f2896/file-lPs3SGl21v.png"
+				/>
+			</p>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-texters/reset-your-spoke-rewired-password.astro
+++ b/src/pages/docs/spoke/for-spoke-texters/reset-your-spoke-rewired-password.astro
@@ -1,0 +1,67 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">Reset Your Spoke Rewired Password</h2>
+
+			<p>
+				If you've forgotten your password, follow these steps to
+				troubleshoot:
+			</p><ol>
+				<li>
+					Navigate to your Spoke Rewired webpage and click "Login and
+					get started."&nbsp;<img
+						src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/634eee524d805871ceaa46b5/file-GlzZZEaNEe.png"
+						style="width: 778px; display: block; margin: auto;"
+						alt=""
+					/>
+				</li>
+
+				<li>
+					From this page, click where the text reads "Forgot your
+					password?" under the LOG IN button.&nbsp;<img
+						src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/634eee9ede258f5018eb56b8/file-q0TwDfajuU.png"
+						style="width: 302px; margin: auto;"
+						alt=""
+					/>
+				</li>
+
+				<li>
+					Input your email and click "Request Reset." This reset
+					request could take up to 15 minutes. Navigate to your email
+					to open the password reset link. You will then be able to
+					reset your password and access Spoke.&nbsp;<img
+						src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/634eef20de258f5018eb56ba/file-12eY11EtWe.png"
+						style="width: 299px; margin: auto;"
+						alt=""
+					/>
+				</li>
+			</ol><h4>Cannot Find Reset Email</h4><p>
+				If you have not received&nbsp;the password reset link, look to
+				see whether you may have registered on Spoke using a different
+				email address. This is a common error.&nbsp;Search for
+				"no-reply@spokerewired.com" in all of your email addresses to
+				identify the email with an active spoke account.&nbsp;
+			</p><p>
+				If you find messages from Spoke Rewired in another email
+				address, navigate to your Spoke webpage and restart the above
+				process with the correct email address. Once you have opened the
+				password reset link and have access to spoke, you can change
+				your email address by clicking the gray bubble with your initial
+				in the top right hand corner and then clicking on your name.
+				This will bring you to the account settings page.&nbsp;
+			</p><p>
+				If you have further questions or difficulties updating your
+				account info, email support@spokerewired.com for further
+				assistance. In your email, please indicate the URL of the Spoke
+				page you are attempting to access.&nbsp;
+			</p>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-texters/send-texts.astro
+++ b/src/pages/docs/spoke/for-spoke-texters/send-texts.astro
@@ -1,0 +1,102 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">Send Texts</h2>
+
+			<p>
+				After you have <a
+					href="https://docs.spokerewired.com/article/41-request-texts-for-assignment"
+					target="_blank">requested</a
+				> and received an assignment, you can begin texting contacts.
+			</p><h2>Sending Initial Messages</h2><h5>
+				<em>To send your initial messages:</em>
+			</h5><ol>
+				<li>
+					Open the texter <a
+						href="https://docs.spokerewired.com/article/52-dashboards"
+						target="_blank">dashboard</a
+					>.
+				</li>
+				<li>Click <strong>Send First Texts</strong>.</li>
+				<li>
+					Click <strong>Send</strong>until you run out of initial
+					messages.<br />
+					<br />
+
+					<blockquote>
+						Note: You cannot edit the initial message.
+					</blockquote>
+				</li>
+			</ol><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/6000fabdcfe30d219ccd80ed/file-HLpARWTSup.png"
+					alt=""
+					style="display: block; margin: auto;"
+				/>
+			</p><p>
+				Following these steps will take the conversations out of your
+				workflow. When contacts begin responding, the conversations will
+				reappear under the <strong style="background-color: initial;"
+					>Send Replies</strong
+				> category.
+			</p><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/6000fb9cb9a8501b295d0bc4/file-eyD56vtF6x.png"
+					alt=""
+					style="display: block; margin: auto;"
+				/>
+			</p><h2>Sending Replies</h2><h5>
+				<em
+					>To send replies to contacts who have responded to an
+					initial message:</em
+				>
+			</h5><ol>
+				<li>
+					Open the texter <a
+						href="https://docs.spokerewired.com/article/52-dashboards"
+						target="_blank">dashboard</a
+					>.
+				</li>
+				<li>Click<strong> Send Replies</strong>.<strong></strong></li>
+				<li>
+					Answer the survey question by clicking below <strong
+						>Current Question</strong
+					> and selecting a survey option. This will automatically populate
+					a prepared response.
+				</li>
+				<li>
+					<em>Optional</em> – Edit the message as needed. We recommend
+					using the response that your Spoke administrators have carefully
+					crafted for you. Think about personalizing the message if the
+					contact asked a direct question or shared something personal
+					with you.
+				</li>
+				<li>Click <strong>Send</strong>.</li>
+			</ol><p>
+				Handling replies will take those conversations out of your
+				workflow, but they'll remain visible on your dashboard as <strong
+					>Past Messages</strong
+				>.
+			</p><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/6000fdd02e764327f87bef53/file-sct50issiZ.png"
+					alt=""
+					style="display: block; margin: auto;"
+				/>
+			</p><p>
+				This is the standard procedure for sending replies. However, in
+				certain cases, you might need to add a tag, opt out a contact,
+				escalate a conversation, use a canned response, or close the
+				conversation. Please see the <strong>Related Articles</strong
+				>&nbsp;below to learn more about these topics.
+			</p>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-texters/texter-training-guide.astro
+++ b/src/pages/docs/spoke/for-spoke-texters/texter-training-guide.astro
@@ -1,0 +1,384 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+  <main class="animate__animated animate__fadeIn animate__slow py-20 md:py-40">
+    <div class="flex items-center flex-col">
+      <h2 class="text-center">Texter Training Guide</h2>
+
+      <p>
+        <a
+          href="https://drive.google.com/file/d/1JnH1Wx4mVezaxJ2bHc6376-3xG0E1M32/view"
+          target="_blank"
+          style="font-family: inherit; font-size: 24px; font-weight: 700;"
+          >Texter Training 101: Watch this short training video*</a
+        >
+      </p><p>
+        *Training contains older versions of Spoke, see screenshots below for
+        the newest version
+      </p><p>
+        This training will teach you to navigate Spoke Rewired, our peer-to-peer
+        text messaging tool. Spoke is a powerful web-based texting platform that
+        allows you to do rapid outreach to mobilize your members, turn out
+        voters, build your base, and more.
+      </p><p>When texting with Spoke, you have two goals:</p><ol>
+        <li>Engage contacts efficiently and thoughtfully</li>
+
+        <li>Log accurate data according to contacts' responses</li>
+      </ol><p>
+        These goals are equally important, and we’ll explain how they fit into
+        the Spoke workflow in the Sending Responses section. We recommend
+        reviewing each section of this training guide to prepare for your first
+        texting shift.&nbsp;
+      </p><p>Welcome!</p>
+      <br />
+      <div>
+        <h2></h2>
+        <h1 style="text-align: center;">TEXTING IN SPOKE REWIRED</h1>
+        <table>
+          <colgroup></colgroup>
+          <tbody> </tbody>
+        </table>
+      </div><h3 style="text-align: center;">SENDING INITIAL TEXTS</h3><p>
+        Whether using your computer, tablet, or smartphone, sending text
+        messages in Spoke is quick and easy. When beginning your texting shift,
+        you should do the following:
+      </p><ol>
+        <li>
+          Start by checking your team's texting guide and any announcements or
+          instructions from your texting leaders.
+        </li>
+
+        <li>
+          Create your account. Your texting leaders will send you a link that
+          will invite you to your texting workspace. Once your account setup is
+          complete, you will either see a text request form or a message
+          indicating that no texts are available. If you see <em
+            >Ready to text?
+          </em>and the green <a
+            href="https://docs.spokerewired.com/article/41-request-texts"
+            target="_blank"><em>Request More Texts</em> button</a
+          >, you can request your first assignment!<em>&nbsp;</em>Your texting
+          leaders have set the maximum amount of texts you can request per
+          batch; feel free to start smaller while you are getting to know the
+          system, but know that batch sizes smaller than 300 are unlikely to
+          provide many immediate replies!<img
+            src="https://lh5.googleusercontent.com/fJpk4sFOteu0_LTwa7kDuDmi-FtWBi1TQUq4lupQvAgPOrlKHN7W6zCryp_Y9w68pMlyTo_JagI3xaU7_rJoPp-7kfQzAAMnicoShExDZ3Hmu4p0huAyZNMsDuhHdrlc1mrpg1CL"
+            width="343"
+            height="208"
+            style="margin: auto;"
+            alt=""
+          />
+        </li>
+        <li>
+          &nbsp;Once your text request has been approved, you will see your
+          first assignment. Click on <em>SEND FIRST TEXTS</em>&nbsp;to enter the
+          conversation screen. The green bubble indicates the number of texts
+          you’ve been assigned.<img
+            src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/5f46cdeb042863444aa0e370/file-BZCsHF3M5d.png"
+          />
+        </li>
+
+        <li>
+          From the conversation screen, the initial text is provided for you.
+          You will not be able to edit this first message. <a
+            href="https://docs.spokerewired.com/article/36-send-texts"
+            target="_blank">Send messages</a
+          > by clicking the <em>SEND</em> button in the lower left or by tapping
+          the enter key on your keyboard. We recommend sending all of your initial
+          messages before fielding your replies!
+          <p>
+            <img
+              src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/62f3fa3980fd5a31e7ad103e/file-12jw0Jse44.png"
+            />
+          </p>
+        </li>
+      </ol><h3 style="text-align: center;">RESPONDING TO REPLIES</h3><p>
+        After sending your first assignment, you can begin <a
+          href="https://docs.spokerewired.com/article/36-send-texts"
+          target="_blank">responding to contacts' replies</a
+        >. Recipients will respond over time, sometimes hours or even days later
+        &mdash; Aim to check your workflow for replies a few times throughout
+        the day to ensure everyone who responds to your initial text receives a
+        reply from you.&nbsp;
+      </p><ol>
+        <li>
+          As replies come into your workflow, you’ll see a <em>SEND REPLIES</em
+          >&nbsp;button appear. The number in the orange bubble indicates the
+          number of replies that need your attention. Unless you need to reopen
+          a conversation that has already taken place, feel free to disregard
+          the <em>PAST MESSAGES</em>&nbsp;or <em>SKIPPED MESSAGES</em>section.
+          Any messages in the <em>SEND LATER</em>&nbsp;bucket will reopen when
+          it reaches 9am in those contacts' local time zone. <br />
+          <br />
+          <strong>Note:</strong> Conversations will only appear in your workflow
+          between 9am-9pm local time for the recipients. If outside of that window,
+          you will not be able to respond to contacts until texting hours reopen.
+          Inbound replies from your contacts will appear the next morning.&nbsp;
+          <img
+            src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/5f4918192c7d3a352e917fb7/file-6IcsLsHrWf.png"
+          />
+        </li>
+
+        <li>
+          <p align="Center" style="text-align: justify;">
+            After clicking the <em>SEND REPLIES</em>button, you’ll see the first
+            reply in your queue. See the following section for instructions on
+            marking the survey according to contacts' responses.&nbsp;<img
+              src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/62f3fb0b61ff5d5f24f9abc5/file-qet697zecs.png"
+            />
+          </p><p align="Center" style="text-align: center;"></p><h3
+            style="text-align: center;"
+          >
+            MARKING SURVEY RESPONSES
+          </h3>
+        </li>
+      </ol><p>
+        Remember: Engaging in a positive conversation with your contacts is
+        equally important to logging accurate data for your campaign or
+        organization. When responding, first ask: Which survey response most
+        accurately captures their response to my question?
+      </p><p>
+        <br /> Click on the survey question below <em>Current question</em>
+      </p><p>
+        <img
+          src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/62f3fcd06d67192dc61b9aed/file-mXV00jGdhf.png"
+        />
+      </p><p>
+        Read all responses carefully to ensure that your choice most accurately
+        reflects their response. For example, note that the survey below
+        includes two distinct options for wrong numbers, <em>Wrong number</em
+        >&nbsp;and&nbsp;<em>Wrong number / Supports CANDIDATE</em>. You would
+        want to choose the latter if the recipient had responded "This is not
+        Adelaide, but I love CANDIDATE! They have my vote!"
+      </p><p>
+        <img
+          src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/62f4000b829a3853b69257fb/file-yKxsQOVPZx.png"
+        />
+      </p><p>
+        If a contact clearly and explicitly asks to no longer receive texts, you
+        must immediately <a
+          href="https://docs.spokerewired.com/article/73-opt-out-a-contact"
+          target="_blank">opt them out</a
+        >.&nbsp;
+      </p><p><strong> Common opt-out responses:</strong></p><ul>
+        <li>“Lose my number.”</li>
+
+        <li>“Remove me.”</li>
+
+        <li>“Don’t text me.”</li>
+
+        <li>“Take me off your list.”</li>
+
+        <li>“Unsubscribe.”</li>
+      </ul><p>
+        Opt Outs are a system feature that prevents your team from ever
+        contacting that phone number again. Follow the instructions of your
+        texting leaders, but do not opt contacts out unless they clearly ask to
+        be removed.
+      </p><p>
+        <img
+          src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/62f401ea4181f8597e7d1402/file-tEOTn7QSw4.png"
+        />
+      </p><p>
+        To opt a contact out, use the orange <em>OPT OUT</em>&nbsp;button at the
+        bottom of your screen. An <em>unsubscribed</em> message will pre-populate;
+        click send to complete the opt out. To opt a contact out without sending
+        a message, delete the prepopulated response and hit <em
+          >Opt out without sending message.
+        </em>This is recommended if the contact responds with something like, "I
+        better not receive one more message from you!" but it is best practice
+        and highly recommended to send the <em>unsubscribed</em
+        >&nbsp;notification.
+      </p><p>
+        <img
+          src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/62f4035a6d67192dc61b9b22/file-2keiIKU8jJ.png"
+        />
+      </p><p>
+        Sometimes the contact asks a question rather than directly responding to
+        the initial message. If possible, mark the survey response accurately
+        but tailor the message to address their question. To find suggested
+        replies to common questions, check <a
+          href="https://docs.spokerewired.com/article/74-use-canned-response"
+          target="_blank">the CANNED RESPONSES section</a
+        > to the right of the <em>OPT OUT</em>&nbsp;button.
+      </p><p>
+        <img
+          src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/62f4043e80fd5a31e7ad106e/file-pO5AutvG4b.png"
+        />
+      </p><p>
+        Clicking on a canned response will automatically populate the message
+        field. If the contact has not addressed the initial question and it
+        feels appropriate to do so, you could use a canned response and then
+        reiterate the initial ask.
+      </p><p>
+        <img
+          src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/62f405bb6d67192dc61b9b2f/file-Cgqk8XGCNr.png"
+        />
+      </p><h3 style="text-align: center;"><br /> APPLYING TAGS</h3><p>
+        In addition to survey responses, data can also be captured through the <a
+          href="https://docs.spokerewired.com/article/58-add-tags-to-a-conversation"
+          target="_blank">application of tags</a
+        >.&nbsp;
+      </p><p>Tags are commonly used to:</p><ul>
+        <li>Indicate that the recipient speaks another language.</li>
+
+        <li>
+          Escalate a conversation to another team or texting leader.&nbsp;
+        </li>
+
+        <li>
+          Log data that doesn't naturally fit into the script, e.g. <em
+            >I want a yard sign!</em
+          >
+        </li>
+      </ul><p>
+        To apply a tag, click <em>MANAGE TAGS</em> at the bottom of your screen.
+      </p><p>
+        <img
+          src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/62f4072e6d67192dc61b9b3f/file-WhAI0wz53P.png"
+        />
+      </p><p>
+        <br /> In the example above, tagging "Spanish" would allow your texting leader
+        to reach out to that contact in their first language the next time around.
+        Depending on your program, you may also have the ability to tag <em
+          >"</em
+        >Reassign to Spanish Speaker" and actually pass that conversation to a
+        Spanish-speaking teammate &mdash; just by applying the tag!&nbsp;
+      </p><p>
+        To find a tag, place your cursor under <em>Apply tags</em
+        >&nbsp;and&nbsp;begin typing. The list will filter to the available tags
+        as you begin typing.
+      </p><p>When the tag appears, select it and click <em>SAVE</em>.</p><p>
+        <img
+          src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/62f4178c61ff5d5f24f9ac9b/file-6xNFCR7pIT.png"
+        />
+      </p><p>
+        From the <em>MANAGE TAGS</em>&nbsp;section, you also have the option to <a
+          href="https://docs.spokerewired.com/article/81-escalate-a-conversation"
+          target="_blank">escalate a conversation</a
+        > directly to your texting leaders.&nbsp;This button should be used with
+        care and according to your team's specific instructions. Texting programs
+        often use this button to transfer messages directly to administrators because
+        they contain:
+      </p><ul>
+        <li>Threats of violence</li>
+
+        <li>
+          Deadnaming, i.e. when a contact identifies as trans or non-binary but
+          your organization's data contains their old, dead name
+        </li>
+
+        <li>
+          Urgent requests. e.g. a canvassing volunteer who is having trouble
+          finding an event location
+          <p>
+            <img
+              src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/62f4181e829a3853b692588f/file-jA2p8rLEnA.png"
+            />
+          </p><p>
+            In general, you should only escalate as the final recourse to an
+            extremely sensitive or urgent conversation.
+          </p>
+        </li>
+      </ul><h3 style="text-align: center;">NAVIGATING CONVERSATIONS</h3><p>
+        If a voter sends a message that doesn’t require a response, you <a
+          href="https://docs.spokerewired.com/article/80-close-conversation"
+          target="_blank">can simply select CLOSE</a
+        ><em>,&nbsp;</em>next to the <em>MANAGE TAGS</em>&nbsp;button.&nbsp;This
+        essentially marks the message as “read” and will move it out of your <em
+          >SEND REPLIES</em
+        >&nbsp;section and into your <em>SKIPPED MESSAGES</em>.
+      </p><p>
+        <img
+          src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/62f4192f80fd5a31e7ad1112/file-hVwqa6Ywu9.png"
+        />
+      </p><p>
+        To leave a reply "unread" so you can come back to it later, you should
+        instead use the NEXT&nbsp;<strong>&gt;</strong>&nbsp;button on the
+        bottom right of your screen. Unlike the <em>CLOSE&nbsp;</em>button,
+        this&nbsp;will allow you to continue working on other replies and easily
+        come back to an unanswered conversation.
+      </p><p>
+        <img
+          src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/62f4199661ff5d5f24f9acae/file-PLIdD0Ft4R.png"
+        />
+      </p><h3></h3><h3></h3><p>
+        When texting on behalf of a campaign or organization, you should
+        consider what each message you send&nbsp;would look like if it appeared
+        on social media without context. Would it reflect well on the program
+        you're supporting? Would other volunteers be proud to say they work
+        alongside you? When responding to sensitive, unpleasant, or triggering
+        messages, ask yourself: “What would it look like if my text conversation
+        went viral?”&nbsp;
+      </p><h3 style="text-align: center;">ENGAGEMENT BEST PRACTICES</h3>
+      <table>
+        <colgroup></colgroup>
+        <tbody>
+          <tr> </tr>
+        </tbody>
+      </table><p>
+        Almost every text list will put you in touch with non-supporters or even
+        trolls who use offensive language to try to bait you into saying
+        something you’d regret. To safeguard ourselves against this, here are a
+        few tips to help when you find yourself in a heated situation:
+      </p><ol>
+        <li>
+          Disengage: Take a break from texting by walking away from your screen
+          to recenter yourself around the goal of your work. Taking a breather
+          can help you collect your thoughts and refocus.
+        </li>
+
+        <li>
+          Lean on survey responses: Make use of the pre-scripted responses to
+          quickly move past negative responders and onto potential supporters.
+        </li>
+
+        <li>
+          Reach out to texting leadership:&nbsp;Don't hesitate to ask for help
+          from your teammates and leadership. They can help you craft a
+          thoughtful response or even take a conversation off your hands.
+        </li>
+      </ol>
+      <br />
+      <div style="text-align: center;">
+        <table>
+          <colgroup></colgroup>
+          <tbody>
+            <tr>
+              <td style="text-align: center;">
+                <h1 style="text-align: center;">
+                  FREQUENTLY ASKED QUESTIONS (FAQS)
+                </h1>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div><p>
+        <strong>Q</strong>: Do I need to download an app in order to use Spoke
+        on my phone?
+      </p><blockquote>
+        <strong>A:</strong> Nope! Spoke is a web-based platform. You can access your
+        workflow through your browser (Google Chrome, Safari, Mozilla Firefox, etc.)
+        and pasting your workflow url in the search bar.
+      </blockquote><p>
+        <strong>Q</strong>: Will using Spoke on my phone share my personal phone
+        number with the contacts I’m texting?
+      </p><blockquote>
+        <strong>A:</strong>No. Spoke is a web-based program that assigns an
+        anonymous phone number for each of our campaigns, so your personal
+        number is always private.
+      </blockquote><p>
+        <strong>Q</strong>: What does it mean when I see a gray box with <em
+          >SEND LATER</em
+        >&nbsp;in Spoke?
+      </p><blockquote>
+        <strong>A:</strong>Spoke enforces sending during 9am-9pm local time. If
+        it's outside of these hours for the person you're attempting to contact,
+        you won't be able to send them a message.
+      </blockquote>
+    </div>
+  </main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-texters/texter-training-guide.astro
+++ b/src/pages/docs/spoke/for-spoke-texters/texter-training-guide.astro
@@ -123,13 +123,13 @@ import "animate.css";
         </li>
 
         <li>
-          <p align="Center" style="text-align: justify;">
+          <p style="text-align: center;" style="text-align: justify;">
             After clicking the <em>SEND REPLIES</em>button, you’ll see the first
             reply in your queue. See the following section for instructions on
             marking the survey according to contacts' responses.&nbsp;<img
               src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/62f3fb0b61ff5d5f24f9abc5/file-qet697zecs.png"
             />
-          </p><p align="Center" style="text-align: center;"></p><h3
+          </p><p style="text-align: center;" style="text-align: center;"></p><h3
             style="text-align: center;"
           >
             MARKING SURVEY RESPONSES

--- a/src/pages/docs/spoke/for-spoke-texters/update-texter-profile.astro
+++ b/src/pages/docs/spoke/for-spoke-texters/update-texter-profile.astro
@@ -1,0 +1,37 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">Update Texter Profile</h2>
+
+			<p>
+				A texter can update their name, email address, and password from
+				the user profile page.
+			</p><p>First, open the dropdown user menu:</p><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/5f2c5ed104286342d763e0bd/file-n1F5Xf81gf.png"
+					style="width: 358px; display: block; margin: auto;"
+					alt=""
+				/>
+			</p><p>Second, click the user information:</p><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/5f2c5f5004286342d763e0c5/file-Hls1K32t0V.png"
+					style="width: 447px; display: block; margin: auto;"
+					alt=""
+				/>
+			</p><p>Finally, make the desired user profile changes:</p><p>
+				<img
+					src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/5f2c5fa304286342d763e0c9/file-R1gkIzKZLT.png"
+					style="width: 792px; display: block; margin: auto;"
+					alt=""
+				/>
+			</p>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/for-spoke-texters/use-canned-response.astro
+++ b/src/pages/docs/spoke/for-spoke-texters/use-canned-response.astro
@@ -1,0 +1,36 @@
+---
+import Layout from "../../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">Use Canned Response</h2>
+
+			<p>
+				Canned responses are messages prepared for you by your Spoke
+				administrators. You can use these in case a conversation goes
+				off script.
+			</p><h5><em>To use a canned response:</em></h5><ol>
+				<li>
+					From a conversation, click <strong>Canned Responses</strong
+					>.
+				</li>
+				<li>Click the canned response you want to use.</li>
+				<li><em>Optional</em> – Edit the response as needed.</li>
+				<li>
+					Click <strong>Send</strong>.
+
+					<p>
+						<img
+							src="https://s3.amazonaws.com/helpscout.net/docs/assets/5d4878eb2c7d3a330e3c1b86/images/62f4043e80fd5a31e7ad106e/file-pO5AutvG4b.png"
+						/>
+					</p>
+				</li>
+			</ol>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/docs/spoke/index.astro
+++ b/src/pages/docs/spoke/index.astro
@@ -1,0 +1,23 @@
+---
+import DocsCollection from "../../../components/DocsCollection/DocsCollectionButton.astro";
+import Layout from "../../../layouts/Layout.astro";
+import "animate.css";
+---
+
+<Layout title="With the Ranks">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
+		<div class="flex items-center flex-col">
+			<h2 class="text-center">Spoke Texting Documentation</h2>
+			<DocsCollection
+				text="For Spoke Texters"
+				link="/withtheranks-astro/docs/spoke/for-spoke-texters"
+			/>
+			<DocsCollection
+				text="For Spoke Administrators"
+				link="/withtheranks-astro/docs/spoke/for-spoke-admins"
+			/>
+		</div>
+	</main>
+</Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,9 +5,9 @@ import "animate.css";
 ---
 
 <Layout title="With the Ranks">
-	<Nav />
-
-	<main class="animate__animated animate__fadeIn animate__slow py-20 md:py-40">
+	<main
+		class="animate__animated animate__fadeIn animate__slow py-20 md:py-40"
+	>
 		<div class="debug hidden" id="color_picker">
 			<label for="favcolor">Logo colors:</label>
 			<input type="color" data-stop-id="stop_one" />
@@ -198,35 +198,4 @@ import "animate.css";
 			});
 		});
 	}
-
-	const toggleButton = document.getElementById('theme-toggle') as HTMLButtonElement;
-
-	function updateIcon(theme: 'light' | 'dark') {
-			const toggleIcon = toggleButton.querySelector('i');
-
-			if (theme === 'light') {
-					toggleIcon?.classList.remove('fa-sun');
-					toggleIcon?.classList.add('fa-moon');
-			} else {
-					toggleIcon?.classList.remove('fa-moon');
-					toggleIcon?.classList.add('fa-sun');
-			}
-	}
-	function setTheme(newTheme: 'light' | 'dark') {
-    document.documentElement.setAttribute('data-theme', newTheme);
-    updateIcon(newTheme);
-    localStorage.setItem('theme', newTheme);
-  }
-
-	toggleButton.addEventListener('click', () => {
-			const currentTheme = document.documentElement.getAttribute('data-theme');
-			const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
-			setTheme(newTheme);
-	});
-
-  // Check local storage for a stored theme preference
-  document.addEventListener('DOMContentLoaded', () => {
-    const storedTheme = (localStorage.getItem('theme') as 'light' | 'dark') || 'dark';
-    setTheme(storedTheme);
-  });
 </script>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,7 +1,6 @@
 ---
 import Layout from "../layouts/Layout.astro";
 import Button from "../components/Button.astro";
-import Nav from "../components/Nav.astro";
 import "animate.css";
 ---
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -14,7 +14,9 @@ import "animate.css";
 			<input type="color" data-stop-id="stop_two" />
 		</div>
 
-		<header class="max-w-screen-2xl w-11/12 md:w-10/12 mx-auto relative z-0">
+		<header
+			class="max-w-screen-2xl w-11/12 md:w-10/12 mx-auto relative z-0"
+		>
 			<!-- Logo -->
 			<svg
 				fill="none"
@@ -93,7 +95,9 @@ import "animate.css";
 			</svg>
 		</header>
 
-		<div class="max-w-screen-xl w-11/12 md:w-7/12 mx-auto md:-translate-y-20 pt-10">
+		<div
+			class="max-w-screen-xl w-11/12 md:w-7/12 mx-auto md:-translate-y-20 pt-10"
+		>
 			<h1 class="text-5xl md:text-6xl lg:text-7xl xl:text-8xl">
 				We build great tech for good causes.
 			</h1>
@@ -107,9 +111,10 @@ import "animate.css";
 				We work with folks like <a
 					href="https://350.org"
 					target="_blank">350.org</a
-				>, <a href="https://berniesanders.org" target="_blank">Bernie Sanders</a>, <a
-					href="https://ambriaforalderman.org"
-					target="_blank">Ambria Taylor for Alderman</a
+				>, <a href="https://berniesanders.org" target="_blank"
+					>Bernie Sanders</a
+				>, <a href="https://ambriaforalderman.org" target="_blank"
+					>Ambria Taylor for Alderman</a
 				>, <a href="https://uwunited.org" target="_blank"
 					>Unemployed Workers United</a
 				>, <a
@@ -142,7 +147,10 @@ import "animate.css";
 				> - we'd love to meet!
 			</p>
 
-			<Button text="Get in touch!" link="mailto:hello@withtheranks.com&subject=Hello!" />
+			<Button
+				text="Get in touch!"
+				link="mailto:hello@withtheranks.com&subject=Hello!"
+			/>
 		</div>
 	</main>
 </Layout>

--- a/src/styles/types.ts
+++ b/src/styles/types.ts
@@ -1,0 +1,1 @@
+export type themeMode = "light" | "dark";

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,4 @@
+export type LinkProps = {
+    text: string;
+    link: string;
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,11 @@
+export const kebabCasetoTitleCase = (str: string) => {
+    const wordsArray = str.split('-');
+    const capitalizedArray = wordsArray.map(word => {
+        // If the word starts with a number, make the whole word uppercase
+        return (/^\d/.test(word)) ? word.toUpperCase() :
+            (word.charAt(0).toUpperCase() + word.slice(1));
+    });
+
+    const title = capitalizedArray.join(' ');
+    return title;
+};


### PR DESCRIPTION
## Description

This adds the Spoke Docs exported from [docs.spokerewired.com](docs.spokerewired.com) (via https://github.com/ajohn25/helpscout-docs-download) as well as some new pages for doc "collections" to the site.

Turned out to be a good exercise for building things with Astro!

Note:
- Since the docs were easy to export as HTML, I skipped a conversion to Markdown since that could potentially create more work to fix formatting than currently exists. There's better first class Astro support for [managing content collections as Markdown](https://docs.astro.build/en/guides/content-collections) so this could be something for us to consider at some point #17 
- Files added in cc15db29f3d79f655c6f3e0d1c9beb63c965c54e (aka files in `pages/docs/spoke` that are not `index.astro` files) don't need a full review at this time, as they're the exported doc files with some bulk edited HTML to fit better into this repo. There will be a number of dead links, styling, etc. to fix and punting that work to #16 
- I bumped Vite locally before triggering #14 so rebasing off of it for convenience instead of removing the duplicate changes from the commit history
- Inline comments on specifics

## Motivation and Context
Closes #8 

## How Has This Been Tested?

This has been tested locally

## Screenshots (if appropriate):
Examples for:

Article that needs less clean up
![image](https://github.com/With-the-Ranks/withtheranks-astro/assets/76596635/12aef6e3-ad82-4992-a5d3-1bcd3e6d321e)

Article that could use more clean up
![image](https://github.com/With-the-Ranks/withtheranks-astro/assets/76596635/71cfb25a-94bb-4f51-87a3-5bd0447a479a)
