### PR TITLE
Fix button props

### DIFF
--- a/src/components/Button.astro
+++ b/src/components/Button.astro
@@ -2,6 +2,7 @@
 import type { LinkProps } from "../types";
 
 interface Props extends LinkProps {
+    id: string;
     class?: string;
 }
 


### PR DESCRIPTION
This adds the id prop back to our button component, which came from a regression introduced in #24 