### PR TITLE
Update deploy pipeline to use latest versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout your repository using git
         uses: actions/checkout@v4
       - name: Install, build, and upload your site
-        uses: withastro/action@v1
+        uses: withastro/action@v3
         # with:
           # path: . # The root location of your Astro project inside the repository. (optional)
           # node-version: 18 # The specific version of Node that should be used to build your site. Defaults to 18. (optional)
@@ -36,4 +36,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
In #47 we updated the 1st component of our pipeline, `actions/checkout`, which succcessfully resolved a corresponding error when deploying. But we still need to do the same for the other GH actions we're running here. With all the changes added, we now match up well with the updated Astro docs https://docs.astro.build/en/guides/deploy/github/#configure-a-github-action

The latest failed deploy can be found here for reference: https://github.com/With-the-Ranks/withtheranks-astro/actions/runs/13167290597/job/36750349135