### PR TITLE
Add Spoke feature copy

### DIFF
--- a/src/pages/texting.astro
+++ b/src/pages/texting.astro
@@ -54,40 +54,49 @@ import "animate.css";
 				time on meaningful conversations with supporters. Here are some of the
 				features that make it the best tool for the job:
 			</p>
-			<!-- grab box: autoassignment, autosending, contact overlap, bulk replacement, opt outs, auto replies (soon) -->
-
-			<!-- Scrolling Partner Logos -->
 			<div class='relative overflow-hidden w-full max-w-5xl mx-auto mb-12'>
 				<div class='grid grid-cols-3 gap-8'>
 					<div
 						class='bg-[#959AF6] bg-opacity-20 rounded-2xl sm:rounded-3xl lg:rounded-[32px] p-2 sm:p-2 lg:p-6 xl:p-6 md:sticky md:top-10 overflow-hidden'
 					>
-						<h3 class='font-bold mb-3'>Delegate Conversations</h3>
-						<p>
-							Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-							eiusmod tempor incididunt ut labore et dolore magnam aliquam
-							quaerat voluptatem.
-						</p>
-					</div>
-					<div
-						class='bg-[#959AF6] bg-opacity-20 rounded-2xl sm:rounded-3xl lg:rounded-[32px] p-2 sm:p-2 lg:p-6 xl:p-6 md:sticky md:top-10 overflow-hidden'
-					>
-						<h3 class='font-bold mb-3'>Workflow Management</h3>
-						<p>
-							Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-							eiusmod tempor incididunt ut labore et dolore magnam aliquam
-							quaerat voluptatem.
-						</p>
-					</div>
-					<div
-						class='bg-[#959AF6] bg-opacity-20 rounded-2xl sm:rounded-3xl lg:rounded-[32px] p-2 sm:p-2 lg:p-6 xl:p-6 md:sticky md:top-10 overflow-hidden'
-					>
-						<h3 class='font-bold mb-3'>A/B Testing</h3>
-						<p>
-							Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-							eiusmod tempor incididunt ut labore et dolore magnam aliquam
-							quaerat voluptatem.
-						</p>
+                        <h3 class="font-bold mb-3">Delegate Conversations</h3>
+                        <aside>
+                            Spoke automates tedious tasks so that organizers can focus on
+                            organizing:
+                        </aside>
+                        <ul class="list-disc text-xl space-y-2 mt-6">
+                            <li>Bulk Send Initial Messages</li>
+                            <li>Auto Assign Replies</li>
+                            <li>Opt Out Keywords</li>
+                        </ul>
+                    </div>
+                    <div
+                        class="bg-[#959AF6] bg-opacity-20 rounded-2xl sm:rounded-3xl lg:rounded-[32px] p-2 sm:p-2 lg:p-6 xl:p-6 md:sticky md:top-10 overflow-hidden"
+                    >
+                        <h3 class="font-bold mb-3">Workflow Management</h3>
+                        <aside class="mb-6">
+                            Spoke allows you to perform common admin workflows in just a few
+                            clicks:
+                        </aside>
+                        <ul class="list-disc text-xl space-y-2 mt-6">
+                            <li>Second Pass Marking</li>
+                            <li>Contact Overlap Management</li>
+                            <li>Bulk Script <br /> Editor</li>
+                        </ul>
+                    </div>
+                    <div
+                        class="bg-[#959AF6] bg-opacity-20 rounded-2xl sm:rounded-3xl lg:rounded-[32px] p-2 sm:p-2 lg:p-6 xl:p-6 md:sticky md:top-10 overflow-hidden"
+                    >
+                        <h3 class="font-bold mb-3">Organize Your Way</h3>
+                        <aside>
+                            Spoke has a variety of features to help you configure your
+                            instance for your team's specific needs:
+                        </aside>
+                        <ul class="list-disc text-xl space-y-2 mt-5">
+                            <li>VAN Data Integration</li>
+                            <li>A/B Script Versions</li>
+                            <li>Team Level Assignments</li>
+                        </ul>
 					</div>
 				</div>
 			</div>

--- a/src/pages/texting.astro
+++ b/src/pages/texting.astro
@@ -89,7 +89,7 @@ import "animate.css";
                     >
                         <h3 class="font-bold mb-3">Organize Your Way</h3>
                         <aside>
-                            Spoke has a variety of features to help you configure your
+                            Spoke features to help you configure your
                             instance for your team's specific needs:
                         </aside>
                         <ul class="list-disc text-xl space-y-2 mt-5">

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -345,7 +345,6 @@ article ul {
 }
 
 article li {
-    font-size: 1.5rem;    
     font-family: 'Crimson Text', serif;
 }
 


### PR DESCRIPTION
This adds Spoke feature details to complete copy for the Spoke marketing page. The included change to `main.css` allows for some more flexible styling with lists