### PR TITLE
Center homepage image on mobile

### DIFF
--- a/src/components/Partners.astro
+++ b/src/components/Partners.astro
@@ -100,7 +100,7 @@ import "animate.css";
 <!-- Full Width Image Section with Dynamic Background Attachment -->
 <section
 	id='bgSection'
-	class='relative w-full h-[850px] md:h-[980px] pb-10 bg-scroll bg-cover bg-right-top'
+	class='relative w-full h-[850px] md:h-[980px] pb-10 bg-scroll bg-cover bg-center md:bg-right-top'
 	style="background-image: url('/assets/bernie-bg.png');"
 >
 	<div


### PR DESCRIPTION
Fix:
<img width="406" alt="Screenshot 2025-03-12 at 4 20 05 PM" src="https://github.com/user-attachments/assets/f2f77e86-f8f1-4f09-b1b1-17bbce3f5e08" />
to:
<img width="388" alt="Screenshot 2025-03-12 at 4 26 18 PM" src="https://github.com/user-attachments/assets/3030c91d-4d2f-458a-b316-d0545276dc1b" />

