### PR TITLE
Fix contact link

### DIFF
--- a/src/pages/our-work.astro
+++ b/src/pages/our-work.astro
@@ -24,7 +24,7 @@ import Timeline from "../components/Timeline.astro";
 								"Working on mobilizing people for good? We're currently booking work for 2025.",
 							link: {
 								text: "Let us know what you're working on",
-								href: "/careers",
+								href: "/contact",
 							},
 						},
 					],


### PR DESCRIPTION
Connect with us should go to /contact not /careers.