### PR TITLE
Tidy spoke form

### DIFF
--- a/src/components/react/InquiryForm.tsx
+++ b/src/components/react/InquiryForm.tsx
@@ -436,6 +436,7 @@ const InquiryForm: React.FC<InquiryFormProps> = ({
 										placeholder="Short description of your organization's work"
 										value={formData.orgDescription}
 										onChange={handleChange}
+										required
 										className='bg-white/10 border-white/20  placeholder:text-white min-h-[100px] md:min-h-[120px] rounded-xl'
 									/>
 								</>
@@ -513,7 +514,7 @@ const InquiryForm: React.FC<InquiryFormProps> = ({
 								<Input
 									type='text'
 									name='primaryLocation'
-									placeholder='Primary Location (for phone number)'
+									placeholder='Preferred Area Code / Zip Code (for phone number)'
 									value={formData.primaryLocation}
 									onChange={handleChange}
 									className='bg-white/10 border-white/20  placeholder:text-white rounded-xl h-10 md:h-12'
@@ -521,9 +522,10 @@ const InquiryForm: React.FC<InquiryFormProps> = ({
 								<Input
 									type='text'
 									name='subdomain'
-									placeholder='Preferred Subdomain'
+									placeholder='Preferred Subdomain (ex. "myorg" will become myorg.spokewtr.com)'
 									value={formData.subdomain}
 									onChange={handleChange}
+									required
 									className='bg-white/10 border-white/20  placeholder:text-white rounded-xl h-10 md:h-12'
 								/>
 								<Textarea
@@ -531,6 +533,7 @@ const InquiryForm: React.FC<InquiryFormProps> = ({
 									placeholder='Billing Address'
 									value={formData.billingAddress}
 									onChange={handleChange}
+									required
 									className='bg-white/10 border-white/20  placeholder:text-white min-h-[100px] md:min-h-[120px] rounded-xl'
 								/>
 							</div>
@@ -578,7 +581,7 @@ const InquiryForm: React.FC<InquiryFormProps> = ({
 										})
 									}>
 									<SelectTrigger className='bg-white/10 border-white/20  rounded-xl'>
-										<SelectValue placeholder="What's your expected audience size?" />
+										<SelectValue placeholder="What's your expected monthly audience size?" />
 									</SelectTrigger>
 									<SelectContent>
 										<SelectItem value='small'>Less than 1,000</SelectItem>

--- a/src/lib/emails/inquiryTemplate.ts
+++ b/src/lib/emails/inquiryTemplate.ts
@@ -141,7 +141,7 @@ export const getInquiryHtml = ({
           ${renderField("Billing Address", billingAddress)}
           ${renderField("How Did You Hear About Us?", hearAboutUs)}
           ${renderField("Audience Size", audienceSize)}
-          ${renderField("Budget", budget)}
+          ${inquiryType !== "spoke-services" && renderField("Budget", budget)}
         </div>
 
         <p class="text">

--- a/src/lib/emails/inquiryTemplate.ts
+++ b/src/lib/emails/inquiryTemplate.ts
@@ -141,7 +141,7 @@ export const getInquiryHtml = ({
           ${renderField("Billing Address", billingAddress)}
           ${renderField("How Did You Hear About Us?", hearAboutUs)}
           ${renderField("Audience Size", audienceSize)}
-          ${inquiryType !== "spoke-services" && renderField("Budget", budget)}
+          ${inquiryType === "spoke-services" ? "" : renderField("Budget", budget)}
         </div>
 
         <p class="text">


### PR DESCRIPTION
This is a bundle of small enhancements to the Spoke intake form as more clients use it:

1. Require org description + subdomain
2. Add clarity for Primary Location + Subdomain descriptions
3. Remove budget from email (not ever displayed in the spoke variant of the form)