### PR TITLE
Update various styles

### DIFF
--- a/src/components/AboutSection.astro
+++ b/src/components/AboutSection.astro
@@ -16,7 +16,7 @@ import Button from "./Button.astro";
     <div class="mx-auto max-w-screen-2xl lg:grid lg:min-h-[680px] lg:grid-cols-2">
       <div class="hidden lg:block"></div>
 
-      <div class="bg-brand-ink px-4 py-16 sm:px-6 lg:py-32 lg:pl-16 lg:pr-0">
+      <div class="bg-brand-ink px-4 py-16 sm:px-6 lg:py-32 lg:pl-16">
         <div class="mx-auto max-w-lg text-left text-white lg:relative lg:z-10 lg:-ml-28 lg:mr-0 lg:max-w-3xl lg:text-right">
           <h2 class="heading-about mb-4 font-display font-normal text-white">
             A worker cooperative building world-class technology.

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -14,7 +14,7 @@ const socialIcons = [
 ---
 
 <footer class="border-black/20 bg-brand-blue-deep text-brand-cream">
-  <div class="mx-auto max-w-screen-2xl px-4 py-16 sm:px-6 sm:py-20 lg:px-8 lg:py-28">
+  <div class="mx-4 max-w-screen-2xl px-4 py-16 sm:px-6 sm:py-20 lg:px-24 lg:py-28">
     <div class="mt-20 mb-16 sm:mt-24 lg:mt-0 lg:mb-20">
       <img alt="With the Ranks Worker Cooperative" class="mx-auto h-auto w-full max-w-full" src="/assets/home/footer-wordmark.svg" />
     </div>

--- a/src/components/HeroSection.astro
+++ b/src/components/HeroSection.astro
@@ -5,12 +5,11 @@ import AnnouncementBanner from "./AnnouncementBanner.astro";
 <section class="bg-brand-blue">
   <div class="mx-auto max-w-screen-2xl px-4 pb-8 sm:px-6 lg:px-8 lg:pb-12">
     <div class="flex flex-col items-center gap-10 pb-10 pt-4 text-center sm:gap-12 lg:gap-16 lg:pt-10">
-      <AnnouncementBanner
+      <!-- <AnnouncementBanner
         href="/about"
         text="We’re celebrating six years of cooperative tech at With the Ranks."
         boldText="See what’s next!"
-      />
-
+      /> -->
       <div class="max-w-6xl">
         <h1 class="heading-hero mb-4 font-display font-normal text-white sm:mb-6">
           We build great tech<br />


### PR DESCRIPTION
- Remove the “we’re celebrating six years of cooperative tech” link in hero
- Add padding on the right of the text in the “a worker coop”/bernie section on md
- With the ranks logo at bottom should have padding around it so it’s not so huge
